### PR TITLE
fix price restriction formatting

### DIFF
--- a/crowdin/lang/en-US/messages.yml
+++ b/crowdin/lang/en-US/messages.yml
@@ -296,6 +296,8 @@ support-disable-reason:
 supertool-is-disabled: <red>Super tool is disabled. Cannot break any shops.
 unknown-owner: Unknown
 restricted-prices: '<red>Restricted price for {0}: Min {1}, max {2}'
+restricted-price-max: '<red>Restricted price for {0}: Max {1}'
+restricted-price-min: '<red>Restricted price for {0}: Min {1}'
 nearby-shop-this-way: <green>Shop is {0} block(s) away from you.
 owner-bypass-check: <yellow>Bypassed all checks. Trade successful! (You are now the shop owner!)
 april-rick-and-roll-easter-egg: "<hover:show_text:'Click to open in browser for time limited rewards!'><click:open_url:'https://www.youtube.com/watch?v=dQw4w9WgXcQ'><green>Click here to acquire your time limited rewards that provided by QuickShop-Hikari developer!</green></click></hover>"

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
@@ -43,8 +43,8 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     private final QuickShop plugin;
     private final Map<String, RuleSet> rules = new LinkedHashMap<>();
     private boolean wholeNumberOnly = false;
-    private double undefinedMin = 0.0d;
-    private double undefinedMax = Double.MAX_VALUE;
+    private double undefinedMin = -1;
+    private double undefinedMax = -1;
 
     public SimplePriceLimiter(@NotNull QuickShop plugin) {
         this.plugin = plugin;
@@ -72,8 +72,8 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
                 plugin.logger().warn("Failed to save migrated  price-restriction.yml.yml to plugin folder!", e);
             }
         }
-        this.undefinedMax = configuration.getDouble("undefined.max", 99999999999999999999999999999.99d);
-        this.undefinedMin = configuration.getDouble("undefined.min", 0.0d);
+        this.undefinedMin = configuration.getDouble("undefined.min", -1);
+        this.undefinedMax = configuration.getDouble("undefined.max", -1);
         this.wholeNumberOnly = configuration.getBoolean("whole-number-only", false);
         if (!configuration.getBoolean("enable", false)) {
             return;
@@ -177,6 +177,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
 
         double minPrice = 0;
         double maxPrice = 0;
+        boolean hasMinPrice = false;
         boolean hasMaxPrice = false;
         final List<ItemStack> flattenedItems = ItemContainerUtil.flattenContents(itemStack, true, false);
 
@@ -194,6 +195,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
             }
 
             if (rule.hasMinPrice()) {
+                hasMinPrice = true;
                 minPrice += rule.getMin() * itemTally;
             }
             if (rule.hasMaxPrice()) {
@@ -202,14 +204,11 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
             }
         }
 
-        if (price < minPrice || (hasMaxPrice && price > maxPrice)) {
-            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, minPrice, maxPrice);
-        }
-        if (undefinedMin != -1 && price < undefinedMin) {
-            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
-        }
-        if (undefinedMax != -1 && price > undefinedMax) {
-            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
+        if ((hasMinPrice && price < minPrice) || (hasMaxPrice && price > maxPrice)
+                || (undefinedMin > 0 && price < undefinedMin) || (undefinedMax >= 0 && price > undefinedMax)) {
+            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED,
+                    hasMinPrice ? minPrice : undefinedMin,
+                    hasMaxPrice ? maxPrice : undefinedMax);
         }
         return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, undefinedMin, undefinedMax);
     }
@@ -243,6 +242,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
 
         double minPrice = 0;
         double maxPrice = 0;
+        boolean hasMinPrice = false;
         boolean hasMaxPrice = false;
         final List<ItemStack> flattenedItems = ItemContainerUtil.flattenContents(itemStack, true, false);
 
@@ -260,6 +260,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
             }
 
             if (rule.hasMinPrice()) {
+                hasMinPrice = true;
                 minPrice += rule.getMin() * itemTally;
             }
             if (rule.hasMaxPrice()) {
@@ -268,14 +269,11 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
             }
         }
 
-        if (price < minPrice || (hasMaxPrice && price > maxPrice)) {
-            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, minPrice, maxPrice);
-        }
-        if (undefinedMin != -1 && price < undefinedMin) {
-            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
-        }
-        if (undefinedMax != -1 && price > undefinedMax) {
-            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
+        if ((hasMinPrice && price < minPrice) || (hasMaxPrice && price > maxPrice)
+                || (undefinedMin > 0 && price < undefinedMin) || (undefinedMax >= 0 && price > undefinedMax)) {
+            return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED,
+                    hasMinPrice ? minPrice : undefinedMin,
+                    hasMaxPrice ? maxPrice : undefinedMax);
         }
         return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, undefinedMin, undefinedMax);
     }

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -374,6 +374,8 @@ support-disable-reason:
 supertool-is-disabled: <red>Super tool is disabled. Cannot break any shops.
 unknown-owner: Unknown
 restricted-prices: '<red>Restricted price for {0}: Min {1}, max {2}'
+restricted-price-max: '<red>Restricted price for {0}: Max {1}'
+restricted-price-min: '<red>Restricted price for {0}: Min {1}'
 nearby-shop-this-way: <green>Shop is {0} block(s) away from you.
 owner-bypass-check: <yellow>Bypassed all checks. Trade successful! (You are now the
   shop owner!)

--- a/quickshop-bukkit/src/main/resources/price-restriction.yml
+++ b/quickshop-bukkit/src/main/resources/price-restriction.yml
@@ -2,7 +2,7 @@ version: 3
 whole-number-only: false  # This option not control by enable option, always enabled
 undefined: # This option not control by enable option, always enabled
   min: 0.01 # Can be zero if you want player create a free shop
-  max: 999999999999999999999999999999.99 # Actually this can be up to 1.7976931348623157E308
+  max: -1 # This can be up to 1.7976931348623157E308, or -1 to disable maximum price.
 enable: false
 rules: # Rules set
   example: # Rules name, used for identifier and permission node (quickshop.price.restriction.bypass.<name>)


### PR DESCRIPTION
Only display both min and max price messages if there is a min and max price set. Otherwise, just display one or the other.
Don't decimal format price restriction messages as you may lose required granularity.