### PR TITLE
Fix ShopPurge feature is broken in folia

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopPurger.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopPurger.java
@@ -15,6 +15,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class ShopPurger {
@@ -47,6 +50,7 @@ public class ShopPurger {
     final DatabaseIOUtil ioUtil = new DatabaseIOUtil((SimpleDatabaseHelperV2)plugin.getDatabaseHelper());
     if(!ioUtil.performBackup("shops-auto-purge")) {
       plugin.logger().warn("[Shop Purger] Purge progress declined due backup failure");
+      executing = false;
       return;
     }
     plugin.logger().info("[Shop Purger] Scanning and removing shops....");
@@ -88,14 +92,29 @@ public class ShopPurger {
       }
     }
 
-    final BatchBukkitExecutor<Shop> purgeExecutor = new BatchBukkitExecutor<>();
-    purgeExecutor.addTasks(pendingRemovalShops);
-    purgeExecutor.startHandle(plugin.getJavaPlugin(), (shop)->plugin.getShopManager().deleteShop(shop))
-            .whenComplete((a, b)->{
-              final long usedTime = purgeExecutor.getStartTime().until(Instant.now(), java.time.temporal.ChronoUnit.MILLIS);
+    final AtomicInteger purgedCount = new AtomicInteger(0);
+    final List<CompletableFuture<Void>> deletionFutures = new CopyOnWriteArrayList<>();
+    
+    for(final Shop shop : pendingRemovalShops) {
+      final CompletableFuture<Void> future = QuickShop.folia().getScheduler().runAtLocation(shop.getLocation(), (loc) -> {
+        try {
+          plugin.getShopManager().deleteShop(shop);
+          purgedCount.incrementAndGet();
+        } catch(final Exception e) {
+          plugin.logger().warn("Failed to delete shop " + shop.getShopId(), e);
+        }
+      });
+      deletionFutures.add(future);
+    }
+
+    final long startTime = Instant.now().toEpochMilli();
+    CompletableFuture.allOf(deletionFutures.toArray(new CompletableFuture[0]))
+            .whenComplete((unused, throwable) -> {
+              final long usedTime = Instant.now().toEpochMilli() - startTime;
               plugin.logger().info("[Shop Purger] Total shop {} has been purged, used {}ms",
-                                   pendingRemovalShops.size(),
+                                   purgedCount.get(),
                                    usedTime);
+              executing = false;
             });
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

Please select the type of change this PR represents:

- [ ] feat – New feature
- [X] fix – Bug fix
- [ ] hotfix – Urgent production fix
- [ ] refactor – Code improvement (no behavior change)
- [ ] docs – Documentation/config comment changes only
- [ ] chore – Build/tooling/internal maintenance
- [ ] breaking – Breaking change (requires migration)

> If this is a breaking change, clearly describe the migration steps below.

---

# General Contribution Checklist

- [X] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [X] My branch name follows the naming conventions in CONTRIBUTING.md.
- [X] I have signed the Contributor License Agreement (CLA), if required.
- [X] My changes are based on the latest `hikari` branch.
- [X] I have tested my changes locally.
- [X] Existing functionality has not been unintentionally broken.

---

# Description of Changes

Clearly explain:

Fix ShopPurge feature is broken in folia

Example:

> This PR fixes incorrect tax calculation when `show: false` caused balance overflow checks to misbehave.

---

# Configuration Changes (if applicable)

If this PR modifies config.yml or another configuration file or adds new configuration options:

- [ ] All new config entries follow [CONFIG-STYLE.md](.contributing/config-style.md).
- [ ] Comments follow the required structure:
  - Plain-English purpose
  - Behavior details (if needed)
  - Advanced notes (if applicable)
  - Warnings (if applicable)
- [ ] Section placement follows the defined ordering rules.
- [ ] Defaults favor safety and stability.
- [ ] Risky settings include `WARNING:` comments and mitigation guidance.
- [ ] Deprecated keys (if any) are clearly marked and documented.
- [ ] No existing config defaults were changed unintentionally.

If config changes were made, explain them:

```markdown
Example:
Added shop.async-price-validation
- Default: false
- Purpose: Improves responsiveness on large servers
- Risk: May increase async task load
```

---

# Migration Notes (Required for breaking changes)

If this PR includes a breaking change:

* What changed?
* Who is affected?
* Required admin action?
* Is there automatic migration?

Example:

```markdown
- shop.display-type=1 is no longer supported.
- Servers must switch to display-type=2.
- No automatic migration is performed.
```

---

# Related Issues / References

* Fixes: #___
* Relates to: #___
* Documentation PR: #___

---

# Testing Notes

How was this tested?

* [X] Local test server
* [ ] Networked proxy setup
* [ ] With database (MySQL)
* [X] With H2
* [ ] Other integrations (describe below)

Additional notes:

---

# Changelog Entry

- Fix issue with purge feature is broken in Folia(YuanYuanOwO)

```markdown
### Fix
- Corrected progressive tax bracket calculation edge case.(creatorfromhell)
```

---

# Maintainer Review Checklist (Internal)
<!--
 Only a member of the QuickShop community maintainer should fill this part out.
-->

* [ ] Code structure meets project standards
* [ ] No unintended side effects
* [ ] Config additions follow style guide
* [ ] Documentation updated (if needed)
* [ ] Changelog entry added
* [ ] Breaking change properly labeled

---

Thank you for contributing to QuickShop-Hikari, it means a lot to us!