### PR TITLE
Fix player tab completions not respecting vanish, and revamp PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,142 +1,62 @@
 <!--
-Thank you for contributing to QuickShop-Hikari! 
-Please complete all relevant sections below before requesting review.
+Thanks for contributing to QuickShop-Hikari!
 -->
 
-# Type of Change
+## Summary
 
-Please select the type of change this PR represents:
+What does this PR do?
 
-- [ ] feat – New feature
-- [ ] fix – Bug fix
-- [ ] hotfix – Urgent production fix
-- [ ] refactor – Code improvement (no behavior change)
-- [ ] docs – Documentation/config comment changes only
-- [ ] chore – Build/tooling/internal maintenance
-- [ ] breaking – Breaking change (requires migration)
-
-> If this is a breaking change, clearly describe the migration steps below.
+> Example: Fix tax calculation when display is disabled
 
 ---
 
-# General Contribution Checklist
+## Type of Change
 
-- [ ] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
-- [ ] My branch name follows the naming conventions in CONTRIBUTING.md.
-- [ ] I have signed the Contributor License Agreement (CLA), if required.
-- [ ] My changes are based on the latest `hikari` branch.
-- [ ] I have tested my changes locally.
-- [ ] Existing functionality has not been unintentionally broken.
-
----
-
-# Description of Changes
-
-Clearly explain:
-
-- What was changed?
-- Why was it changed?
-- What issue does it solve?
-- Is this user-facing, developer-facing, or internal?
-
-Example:
-
-> This PR fixes incorrect tax calculation when `show: false` caused balance overflow checks to misbehave.
+* [ ] Feature
+* [ ] Bug fix
+* [ ] Refactor / Cleanup
+* [ ] Documentation
+* [ ] Breaking change
 
 ---
 
-# Configuration Changes (if applicable)
+## Basic Checks
 
-If this PR modifies config.yml or another configuration file or adds new configuration options:
-
-- [ ] All new config entries follow [CONFIG-STYLE.md](.contributing/config-style.md).
-- [ ] Comments follow the required structure:
-  - Plain-English purpose
-  - Behavior details (if needed)
-  - Advanced notes (if applicable)
-  - Warnings (if applicable)
-- [ ] Section placement follows the defined ordering rules.
-- [ ] Defaults favor safety and stability.
-- [ ] Risky settings include `WARNING:` comments and mitigation guidance.
-- [ ] Deprecated keys (if any) are clearly marked and documented.
-- [ ] No existing config defaults were changed unintentionally.
-
-If config changes were made, explain them:
-
-```markdown
-Example:
-Added shop.async-price-validation
-- Default: false
-- Purpose: Improves responsiveness on large servers
-- Risk: May increase async task load
-```
+* [ ] I have tested these changes locally
+* [ ] I confirm no undocumented AI-generated code was used in this submission
 
 ---
 
-# Migration Notes (Required for breaking changes)
+## Notes (optional)
 
-If this PR includes a breaking change:
+Add anything important for reviewers:
 
-* What changed?
-* Who is affected?
-* Required admin action?
-* Is there automatic migration?
-
-Example:
-
-```markdown
-- shop.display-type=1 is no longer supported.
-- Servers must switch to display-type=2.
-- No automatic migration is performed.
-```
+* Why this change was needed
+* Edge cases
+* Implementation details
 
 ---
 
-# Related Issues / References
+## Config Changes (if applicable)
 
-* Fixes: #___
-* Relates to: #___
-* Documentation PR: #___
+Only fill this out if you touched config:
 
----
-
-# Testing Notes
-
-How was this tested?
-
-* [ ] Local test server
-* [ ] Networked proxy setup
-* [ ] With database (MySQL)
-* [ ] With H2
-* [ ] Other integrations (describe below)
-
-Additional notes:
+* Added/changed:
+* Default values:
+* Any risks or notes:
 
 ---
 
-# Changelog Entry
+## Breaking Changes (if applicable)
 
-If this change is user-facing, provide a changelog entry, which also includes your name/online alias:
-
-```markdown
-### Fix
-- Corrected progressive tax bracket calculation edge case.(creatorfromhell)
-```
+* What changed:
+* Required action:
 
 ---
 
-# Maintainer Review Checklist (Internal)
-<!--
- Only a member of the QuickShop community maintainer should fill this part out.
--->
+## Related (optional)
 
-* [ ] Code structure meets project standards
-* [ ] No unintended side effects
-* [ ] Config additions follow style guide
-* [ ] Documentation updated (if needed)
-* [ ] Changelog entry added
-* [ ] Breaking change properly labeled
+* Fixes Issue #
+* Related to Issue/PR #
 
 ---
-
-Thank you for contributing to QuickShop-Hikari, it means a lot to us!

--- a/addon/list/src/main/java/com/ghostchu/quickshop/addon/list/command/SubCommand_List.java
+++ b/addon/list/src/main/java/com/ghostchu/quickshop/addon/list/command/SubCommand_List.java
@@ -63,7 +63,7 @@ public class SubCommand_List implements CommandHandler<Player> {
 
     if(parser.getArgs().size() == 1) {
       if(quickshop.perm().hasPermission(sender, "quickshopaddon.list.other")) {
-        return getPlayerList();
+        return getPlayerList(sender);
       }
     }
     if(parser.getArgs().size() == 2) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_RemoveAll.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_RemoveAll.java
@@ -74,6 +74,6 @@ public class SubCommand_RemoveAll implements CommandHandler<CommandSender> {
   @Override
   public @Nullable List<String> onTabComplete(@NotNull final CommandSender sender, @NotNull final String commandLabel, @NotNull final CommandParser parser) {
 
-    return parser.getArgs().size() <= 1? getPlayerList() : Collections.emptyList();
+    return parser.getArgs().size() <= 1? getPlayerList(sender) : Collections.emptyList();
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_SetOwner.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_SetOwner.java
@@ -82,7 +82,7 @@ public class SubCommand_SetOwner implements CommandHandler<Player> {
   public List<String> onTabComplete(
           @NotNull final Player sender, @NotNull final String commandLabel, @NotNull final CommandParser parser) {
 
-    return parser.getArgs().size() <= 1? getPlayerList() : Collections.emptyList();
+    return parser.getArgs().size() <= 1? getPlayerList(sender) : Collections.emptyList();
   }
 
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Staff.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Staff.java
@@ -120,7 +120,7 @@ public class SubCommand_Staff implements CommandHandler<Player> {
     } else if(parser.getArgs().size() == 2) {
       final String prefix = parser.getArgs().getFirst().toLowerCase();
       if("add".equals(prefix) || "del".equals(parser.getArgs().getFirst())) {
-        return Util.getPlayerList();
+        return Util.getPlayerList(sender);
       }
     }
     return Collections.emptyList();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_StaffAll.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_StaffAll.java
@@ -116,7 +116,7 @@ public class SubCommand_StaffAll implements CommandHandler<Player> {
     } else if(parser.getArgs().size() == 2) {
       final String prefix = parser.getArgs().getFirst().toLowerCase();
       if("add".equals(prefix) || "del".equals(parser.getArgs().getFirst())) {
-        return Util.getPlayerList();
+        return Util.getPlayerList(sender);
       }
     }
     return Collections.emptyList();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_TransferAll.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_TransferAll.java
@@ -136,7 +136,7 @@ public class SubCommand_TransferAll implements CommandHandler<Player> {
   @Override
   public @Nullable List<String> onTabComplete(@NotNull final Player sender, @NotNull final String commandLabel, @NotNull final CommandParser parser) {
 
-    final List<String> list = Util.getPlayerList();
+    final List<String> list = Util.getPlayerList(sender);
     list.add("accept");
     list.add("deny");
     return parser.getArgs().size() <= 2? list : Collections.emptyList();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_TransferOwnership.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_TransferOwnership.java
@@ -98,7 +98,7 @@ public class SubCommand_TransferOwnership implements CommandHandler<Player> {
   @Override
   public @Nullable List<String> onTabComplete(@NotNull final Player sender, @NotNull final String commandLabel, @NotNull final CommandParser parser) {
 
-    final List<String> list = Util.getPlayerList();
+    final List<String> list = Util.getPlayerList(sender);
     list.add("accept");
     list.add("deny");
     return parser.getArgs().size() <= 2? list : Collections.emptyList();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -46,6 +46,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -1055,9 +1056,15 @@ public class Util {
    * @return the player names
    */
   @NotNull
-  public static List<String> getPlayerList() {
+  public static List<String> getPlayerList(final CommandSender sender) {
 
-    final List<String> tabList = Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+    final List<String> tabList = new ArrayList<>();
+    if(sender instanceof final Player player) {
+      tabList.addAll(Bukkit.getOnlinePlayers().stream().filter(player::canSee).map(Player::getName).toList());
+    } else {
+      tabList.addAll(Bukkit.getOnlinePlayers().stream().map(Player::getName).toList());
+    }
+
     if(plugin.getConfig().getBoolean("include-offlineplayer-list")) {
       tabList.addAll(Arrays.stream(Bukkit.getOfflinePlayers()).map(OfflinePlayer::getName).filter(Objects::nonNull).toList());
     }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

It removes vanished players from the command tab suggestions and it also updates the PR template to not be overbearing on contributors.

---

## Type of Change

* [ ] Feature
* [X] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [X] I have tested these changes locally
* [X] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

Makes the command arguments align with the players others can see already.

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue # https://github.com/QuickShop-Community/QuickShop-Hikari/issues/2332
* Related to Issue/PR # https://github.com/QuickShop-Community/QuickShop-Hikari/issues/2332

---