### PR TITLE
Perf: Avoid creating emtpy yaml config instances for every shop

### DIFF
--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/Shop.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/Shop.java
@@ -146,10 +146,10 @@ public interface Shop<U, L> extends Locatable<L>, ShopInventory, ShopMeta<U>, Sh
   /**
    * Save the extra data to the shop.
    *
-   * @param plugin Plugin instace
-   * @param data   The data table
+   * @param plugin Plugin instance
+   * @param data   The data table, or null to remove it
    */
-  void setExtra(@NotNull Plugin plugin, @NotNull ConfigurationSection data);
+  void setExtra(@NotNull Plugin plugin, @Nullable ConfigurationSection data);
 
   /**
    * Update shop data to database

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -243,6 +243,10 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
 
   private void updateShopData() {
 
+    if(this.extra == null) {
+      return;
+    }
+
     final ConfigurationSection section = getExtra(plugin.getJavaPlugin());
     if(section.getString("currency") != null) {
       this.currency = section.getString("currency");
@@ -428,11 +432,11 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
   public @NotNull ConfigurationSection getExtra(@NotNull final Plugin plugin) {
 
     if(this.extra == null) {
-      this.extra = new YamlConfiguration();
+      return new YamlConfiguration();
     }
     ConfigurationSection section = extra.getConfigurationSection(plugin.getName());
     if(section == null) {
-      section = extra.createSection(plugin.getName());
+      return new YamlConfiguration();
     }
     return section;
   }
@@ -1680,7 +1684,11 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
    * @param data   The data table
    */
   @Override
-  public void setExtra(@NotNull final Plugin plugin, @NotNull final ConfigurationSection data) {
+  public void setExtra(@NotNull final Plugin plugin, @Nullable final ConfigurationSection data) {
+
+    if(data == null && this.extra == null) {
+      return;
+    }
 
     if(this.extra == null) {
       this.extra = new YamlConfiguration();


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

This PR modifies ContainerShop#getExtra to no longer automatically create empty config sections when invoked, to avoid holding a bunch of empty yaml config instances in memory for no reason. I don't consider this to be a breaking change, since the javadoc of Shop#getExtra mentions that setExtra must be used for it to be reliably saved.

I originally tested this patch with my reremake fork, and based on heap dumps taken before and after, this saved me about 1.3GB worth of ram with a database of ~180000 total shops. (at least, that's how many the startup message said I have)

---

## Type of Change

* [x] Feature

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---