### PR TITLE
Implemented Folia-safe sign check for teleportation in front instead on top

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/browse/ShopListPage.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/browse/ShopListPage.java
@@ -266,10 +266,21 @@ public class ShopListPage {
               .display(QuickShop.getInstance().platform().miniMessage().deserialize("<yellow>" + itemName + "</yellow>"))
               .lore(lore);
 
-      // Get teleport location - use shop location + 1 block up
-      // Note: We avoid calling shop.getSigns() here as it requires block access
-      // which can fail on Folia when the shop is in a different region
-      final Location teleportTarget = shop.bukkitLocation().clone().add(0.5, 1, 0.5);
+      List<Location> possiblePositions = new ArrayList<>();
+      possiblePositions.add(shop.bukkitLocation().clone().add(1, 0, 0));
+      possiblePositions.add(shop.bukkitLocation().clone().add(-1, 0, 0));
+      possiblePositions.add(shop.bukkitLocation().clone().add(0, 0, 1));
+      possiblePositions.add(shop.bukkitLocation().clone().add(0, 0, -1));
+
+      // Check which position has a sign in it
+      Location teleportTarget = null;
+      for(Location loc : possiblePositions) {
+          if(loc.getBlock().getState() instanceof org.bukkit.block.Sign) {
+              teleportTarget = loc.add(0.5, 0, 0.5); // Center of the block
+              break;
+          }
+      }
+
 
       final IconBuilder iconBuilder = new IconBuilder(stack)
               .withSlot(listStartSlot + (i - start));


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

> Teleportation checks sign location of shop and teleports the player there when using /qs browse

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Teleportation on top does not check for safety, neither does this one, but the chance of it being safe will be greater because of how shops are created with this plugin in general.
* Double-chest shops need testing

---

## Breaking Changes (if applicable)

* What changed: Teleport location changed. Could influence users of shops that only know this behaviour.

---