### PR TITLE
Update Display Compatibility for EcoEnchants and Reforges

### DIFF
--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -15,7 +14,6 @@
     <packaging>takari-jar</packaging>
 
     <name>Compat-EcoEnchants</name>
-
     <description>Compatibility module for EcoEnchants</description>
 
     <build>
@@ -23,8 +21,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>kotlin</pattern>
+                                    <shadedPattern>com.willfp.eco.libs.kotlin</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
-
         </plugins>
         <resources>
             <resource>
@@ -62,42 +75,48 @@
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>EcoEnchants</artifactId>
-            <version>${compat.ecoenchants}</version>
+            <version>13.6.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.willfp</groupId>
+            <artifactId>libreforge-loader</artifactId>
+            <version>5.4.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>eco</artifactId>
-            <version>${compat.eco}</version>
+            <version>7.6.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>maven-artifact</artifactId>
                     <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>caffeine</artifactId>
                     <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>net.kyori</groupId>
                     <artifactId>adventure-api</artifactId>
-                    <groupId>net.kyori</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>net.kyori</groupId>
                     <artifactId>adventure-text-serializer-gson</artifactId>
-                    <groupId>net.kyori</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>net.kyori</groupId>
                     <artifactId>adventure-text-serializer-legacy</artifactId>
-                    <groupId>net.kyori</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>kotlin-stdlib</artifactId>
                     <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>kotlinx-coroutines-core-jvm</artifactId>
                     <groupId>org.jetbrains.kotlinx</groupId>
+                    <artifactId>kotlinx-coroutines-core-jvm</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/compatibility/ecoenchants/src/main/java/com/ghostchu/quickshop/compatibility/ecoenchants/Main.java
+++ b/compatibility/ecoenchants/src/main/java/com/ghostchu/quickshop/compatibility/ecoenchants/Main.java
@@ -6,7 +6,6 @@ import com.ghostchu.quickshop.api.event.display.ItemPreviewComponentPrePopulateE
 import com.ghostchu.quickshop.compatibility.CompatibilityModule;
 import com.ghostchu.quickshop.util.logger.Log;
 import com.willfp.eco.core.display.DisplayProperties;
-import com.willfp.ecoenchants.EcoEnchantsPlugin;
 import com.willfp.ecoenchants.display.EnchantDisplay;
 import com.willfp.ecoenchants.enchant.EcoEnchant;
 import com.willfp.ecoenchants.enchant.EcoEnchants;
@@ -15,56 +14,48 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Set;
+import java.util.Collection;
 
 public final class Main extends CompatibilityModule implements Listener {
 
-  private EnchantDisplay display;
-
-  @Override
-  public void init() {
-    // There no init stuffs need to do
-    this.display = new EnchantDisplay(EcoEnchantsPlugin.getPlugin(EcoEnchantsPlugin.class));
-    initEcoEnchantEnchantmentTranslationKeys();
-  }
-
-  @EventHandler(ignoreCancelled = true)
-  public void onPluginLoad(final PluginEnableEvent event) {
-
-    if("EcoEnchants".equalsIgnoreCase(event.getPlugin().getName())
-       || "libreforge".equalsIgnoreCase(event.getPlugin().getName())
-       || "eco".equalsIgnoreCase(event.getPlugin().getName())) {
-      QuickShop.folia().getScheduler().runLater(this::initEcoEnchantEnchantmentTranslationKeys, 1);
+    @Override
+    public void init() {
+        initEcoEnchantEnchantmentTranslationKeys();
     }
-  }
 
-  @Override
-  public void onQuickShopReload(final QSConfigurationReloadEvent event) {
-
-    initEcoEnchantEnchantmentTranslationKeys();
-  }
-
-  private void initEcoEnchantEnchantmentTranslationKeys() {
-
-    final Set<EcoEnchant> enchantSet = EcoEnchants.INSTANCE.values();
-    getLogger().info("Found " + enchantSet.size() + " enchantments from EcoEnchants");
-    for(final EcoEnchant value : enchantSet) {
-      final String key = "ecoenchants:enchantment." + value.getId();
-      getApi().registerLocalizedTranslationKeyMapping(key, value.getRawDisplayName());
-      Log.debug("Registered EcoEnchant " + value.getId() + " with translation key override mapping: " + key + " -> " + value.getRawDisplayName());
+    @EventHandler(ignoreCancelled = true)
+    public void onPluginLoad(final PluginEnableEvent event) {
+        if ("EcoEnchants".equalsIgnoreCase(event.getPlugin().getName())
+                || "libreforge".equalsIgnoreCase(event.getPlugin().getName())
+                || "eco".equalsIgnoreCase(event.getPlugin().getName())) {
+            QuickShop.folia().getScheduler().runLater(this::initEcoEnchantEnchantmentTranslationKeys, 1);
+        }
     }
-    getLogger().info("Initialized " + enchantSet.size() + " EcoEnchants translation keys");
-  }
 
-  @EventHandler(ignoreCancelled = true)
-  public void onItemPreviewPreparing(final ItemPreviewComponentPrePopulateEvent event) {
-
-    if(event.getPlayer() == null) {
-      return;
+    @Override
+    public void onQuickShopReload(final QSConfigurationReloadEvent event) {
+        initEcoEnchantEnchantmentTranslationKeys();
     }
-    final ItemStack stack = event.getItemStack().clone();
-    display.display(stack, event.getPlayer(), display.generateVarArgs(stack));
-    display.display(stack, event.getPlayer(), new DisplayProperties(false, false, stack), display.generateVarArgs(stack));
-    event.setItemStack(stack);
-  }
+
+    private void initEcoEnchantEnchantmentTranslationKeys() {
+        final Collection<EcoEnchant> enchantSet = EcoEnchants.INSTANCE.values();
+        getLogger().info("Found " + enchantSet.size() + " enchantments from EcoEnchants");
+        for (final EcoEnchant value : enchantSet) {
+            final String key = "ecoenchants:enchantment." + value.getId();
+            getApi().registerLocalizedTranslationKeyMapping(key, value.getRawDisplayName());
+            Log.debug("Registered EcoEnchant " + value.getId() + " with translation key override mapping: " + key + " -> " + value.getRawDisplayName());
+        }
+        getLogger().info("Initialized " + enchantSet.size() + " EcoEnchants translation keys");
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onItemPreviewPreparing(final ItemPreviewComponentPrePopulateEvent event) {
+        if (event.getPlayer() == null) {
+            return;
+        }
+        final ItemStack stack = event.getItemStack().clone();
+        final Object[] varArgs = EnchantDisplay.INSTANCE.generateVarArgs(stack);
+        EnchantDisplay.INSTANCE.display(stack, event.getPlayer(), new DisplayProperties(false, false, stack), varArgs);
+        event.setItemStack(stack);
+    }
 }

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -15,7 +14,6 @@
     <packaging>takari-jar</packaging>
 
     <name>Compat-Reforges</name>
-
     <description>Compatibility module for Reforges</description>
 
     <build>
@@ -23,8 +21,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>kotlin</pattern>
+                                    <shadedPattern>com.willfp.eco.libs.kotlin</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
-
         </plugins>
         <resources>
             <resource>
@@ -62,13 +75,49 @@
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>Reforges</artifactId>
-            <version>${compat.reforges}</version>
+            <version>7.5.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>eco</artifactId>
-            <version>${compat.eco}</version>
+            <version>7.6.1</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-text-serializer-gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-text-serializer-legacy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlinx</groupId>
+                    <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.willfp</groupId>
+            <artifactId>libreforge-loader</artifactId>
+            <version>5.4.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/compatibility/reforges/src/main/java/com/ghostchu/quickshop/compatibility/reforges/Main.java
+++ b/compatibility/reforges/src/main/java/com/ghostchu/quickshop/compatibility/reforges/Main.java
@@ -3,7 +3,6 @@ package com.ghostchu.quickshop.compatibility.reforges;
 import com.ghostchu.quickshop.api.event.display.ItemPreviewComponentPrePopulateEvent;
 import com.ghostchu.quickshop.compatibility.CompatibilityModule;
 import com.willfp.eco.core.display.DisplayProperties;
-import com.willfp.reforges.ReforgesPlugin;
 import com.willfp.reforges.display.ReforgesDisplay;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,23 +10,18 @@ import org.bukkit.inventory.ItemStack;
 
 public final class Main extends CompatibilityModule implements Listener {
 
-  private ReforgesDisplay display;
-
-  @Override
-  public void init() {
-    // There no init stuffs need to do
-    this.display = new ReforgesDisplay(ReforgesPlugin.getInstance());
-  }
-
-  @EventHandler(ignoreCancelled = true)
-  public void onItemPreviewPreparing(final ItemPreviewComponentPrePopulateEvent event) {
-
-    if(event.getPlayer() == null) {
-      return;
+    @Override
+    public void init() {
+        // No init needed
     }
-    final ItemStack stack = event.getItemStack().clone();
-    display.display(stack, event.getPlayer(), display.generateVarArgs(stack));
-    display.display(stack, event.getPlayer(), new DisplayProperties(false, false, stack), display.generateVarArgs(stack));
-    event.setItemStack(stack);
-  }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onItemPreviewPreparing(final ItemPreviewComponentPrePopulateEvent event) {
+        if (event.getPlayer() == null) {
+            return;
+        }
+        final ItemStack stack = event.getItemStack().clone();
+        ReforgesDisplay.INSTANCE.display(stack, event.getPlayer(), new DisplayProperties(false, false, stack));
+        event.setItemStack(stack);
+    }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -1048,7 +1048,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
         previewComponentPrePopulateEvent.callEvent();
         previewItemStack = previewComponentPrePopulateEvent.getItemStack();
         Component previewComponent = plugin.text().of(p, "menu.preview", Component.text(previewItemStack.getAmount())).forLocale().clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, MsgUtil.fillArgs("/{0} {1} {2}", plugin.getMainCommand(), plugin.getCommandPrefix("silentpreview"), shop.getRuntimeRandomUniqueId().toString())));
-        previewComponent = plugin.platform().setItemStackHoverEvent(previewComponent, shop.getItem());
+        previewComponent = plugin.platform().setItemStackHoverEvent(previewComponent, previewItemStack);
         final ItemPreviewComponentPopulateEvent itemPreviewComponentPopulateEvent = new ItemPreviewComponentPopulateEvent(previewComponent, p);
         itemPreviewComponentPopulateEvent.callEvent();
         previewComponent = itemPreviewComponentPopulateEvent.getComponent();


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

> - Update EcoEnchants and Reforges compat modules
> - Replace instantiated Display with Display.INSTANCE (now a Kotlin object)
> - Add libreforge-loader 5.4.2 dependency (now required explicitly)
> - Add Kotlin relocation to maven-shade-plugin

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
> - Had to Change `previewComponent = plugin.platform().setItemStackHoverEvent` for it to work.
> From `(previewComponent, shop.getItem());` to `(previewComponent, previewItemStack);`
> Don't know if this causes issues or requires other changes
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---