### PR TITLE
Invalidate cached item preview GUI when shop item changes

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -527,6 +527,11 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
     }
     this.displayItem = null;
     checkDisplay();
+    if(this.inventoryPreview != null) {
+
+      this.inventoryPreview.close();
+      this.inventoryPreview = null;
+    }
     setSignText();
     setDirty();
   }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

> Fix #2296

When setItem() updates the item, it does not invalidate the cached inventoryPreview, causing the preview GUI to always display the stale item from when it was first built.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [ ] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission
