### PR TITLE
Fix price restriction formatting PR.

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Price.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Price.java
@@ -46,15 +46,6 @@ public class SubCommand_Price implements CommandHandler<Player> {
       return;
     }
 
-    final int maximumDigitsInPrice = plugin.getConfig().getInt("shop.maximum-digits-in-price", -1);
-    if(maximumDigitsInPrice != -1) {
-      final int inputScale = Math.max(price.stripTrailingZeros().scale(), 0);
-      if(inputScale > maximumDigitsInPrice) {
-        plugin.text().of(sender, "digits-reach-the-limit", Component.text(maximumDigitsInPrice)).send();
-        return;
-      }
-    }
-
     final double priceDouble = price.doubleValue();
     // No number input
     if(Double.isInfinite(priceDouble) || Double.isNaN(priceDouble)) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
@@ -43,8 +43,8 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
   private final QuickShop plugin;
   private final Map<String, RuleSet> rules = new LinkedHashMap<>();
   private boolean wholeNumberOnly = false;
-  private double undefinedMin = 0.0d;
-  private double undefinedMax = Double.MAX_VALUE;
+  private double undefinedMin = -1;
+  private double undefinedMax = -1;
 
   public SimplePriceLimiter(@NotNull final QuickShop plugin) {
 
@@ -74,8 +74,8 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
         plugin.logger().warn("Failed to save migrated  price-restriction.yml.yml to plugin folder!", e);
       }
     }
-    this.undefinedMax = configuration.getDouble("undefined.max", 99999999999999999999999999999.99d);
-    this.undefinedMin = configuration.getDouble("undefined.min", 0.0d);
+    this.undefinedMax = configuration.getDouble("undefined.max", -1);
+    this.undefinedMin = configuration.getDouble("undefined.min", -1);
     this.wholeNumberOnly = configuration.getBoolean("whole-number-only", false);
     if(!configuration.getBoolean("enable", false)) {
       return;
@@ -184,6 +184,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     double minPrice = 0;
     double maxPrice = 0;
     boolean hasMaxPrice = false;
+    boolean hasMinPrice = false;
     final List<ItemStack> flattenedItems = ItemContainerUtil.flattenContents(itemStack, true, false);
 
     for(final RuleSet rule : rules.values()) {
@@ -200,6 +201,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
       }
 
       if(rule.hasMinPrice()) {
+        hasMinPrice = true;
         minPrice += rule.getMin() * itemTally;
       }
       if(rule.hasMaxPrice()) {
@@ -208,14 +210,12 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
       }
     }
 
-    if(price < minPrice || (hasMaxPrice && price > maxPrice)) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, minPrice, maxPrice);
-    }
-    if(undefinedMin != -1 && price < undefinedMin) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
-    }
-    if(undefinedMax != -1 && price > undefinedMax) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
+    if ((hasMinPrice && price < minPrice) || (hasMaxPrice && price > maxPrice)
+        || (undefinedMin > 0 && price < undefinedMin) || (undefinedMax >= 0 && price > undefinedMax)) {
+
+      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED,
+                                               (hasMinPrice)? minPrice : undefinedMin,
+                                               (hasMaxPrice)? maxPrice : undefinedMax);
     }
     return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, undefinedMin, undefinedMax);
   }
@@ -252,6 +252,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     double minPrice = 0;
     double maxPrice = 0;
     boolean hasMaxPrice = false;
+    boolean hasMinPrice = false;
     final List<ItemStack> flattenedItems = ItemContainerUtil.flattenContents(itemStack, true, false);
 
     for(final RuleSet rule : rules.values()) {
@@ -268,6 +269,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
       }
 
       if(rule.hasMinPrice()) {
+        hasMinPrice = true;
         minPrice += rule.getMin() * itemTally;
       }
       if(rule.hasMaxPrice()) {
@@ -276,14 +278,12 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
       }
     }
 
-    if(price < minPrice || (hasMaxPrice && price > maxPrice)) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, minPrice, maxPrice);
-    }
-    if(undefinedMin != -1 && price < undefinedMin) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
-    }
-    if(undefinedMax != -1 && price > undefinedMax) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED, undefinedMin, undefinedMax);
+    if ((hasMinPrice && price < minPrice) || (hasMaxPrice && price > maxPrice)
+        || (undefinedMin > 0 && price < undefinedMin) || (undefinedMax >= 0 && price > undefinedMax)) {
+
+      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED,
+                                               (hasMinPrice)? minPrice : undefinedMin,
+                                               (hasMaxPrice)? maxPrice : undefinedMax);
     }
     return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, undefinedMin, undefinedMax);
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -47,6 +47,7 @@ import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager;
 import com.ghostchu.quickshop.shop.tax.QuickShopTaxManager;
 import com.ghostchu.quickshop.util.ChatSheetPrinter;
 import com.ghostchu.quickshop.util.MsgUtil;
+import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.holder.Result;
 import com.ghostchu.quickshop.util.logger.Log;
@@ -508,6 +509,11 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       // No number input
       Log.debug("actionCreate had issue with price parameter.");
       plugin.text().of(p, "not-a-number", message).send();
+      return;
+    }
+
+    if(!ShopUtil.isValidPrice(price)) {
+      plugin.text().of(createQUser, "digits-reach-the-limit", Component.text(32)).send();
       return;
     }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -793,13 +793,29 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
 
     // Price limit checking
     final PriceLimiterCheckResult priceCheckResult = this.priceLimiter.check(p, shop.getItem(), plugin.getCurrency(), shop.getPrice());
+    final String currency = (shop.getCurrency() == null)? ((plugin.getCurrency() == null)? "" : plugin.getCurrency()) : shop.getCurrency();
+    final World world = shop.bukkitLocation().getWorld();
+    final EconomyProvider econ = plugin.getEconomyManager().provider();
+
+    final double min = priceCheckResult.getMin();
+    final double max = priceCheckResult.getMax();
+    final String minFormatted = econ != null? econ.format(BigDecimal.valueOf(min), world.getName(), currency) : String.valueOf(min);
+    final String maxFormatted = econ != null? econ.format(BigDecimal.valueOf(max), world.getName(), currency) : String.valueOf(max);
+
     switch(priceCheckResult.getStatus()) {
       case REACHED_PRICE_MIN_LIMIT ->
-              plugin.text().of(p, "price-too-cheap", Component.text((useDecFormat)? MsgUtil.decimalFormat(priceCheckResult.getMax()) : Double.toString(priceCheckResult.getMin()))).send();
+              plugin.text().of(p, "price-too-cheap", minFormatted).send();
       case REACHED_PRICE_MAX_LIMIT ->
-              plugin.text().of(p, "price-too-high", Component.text((useDecFormat)? MsgUtil.decimalFormat(priceCheckResult.getMax()) : Double.toString(priceCheckResult.getMin()))).send();
-      case PRICE_RESTRICTED ->
-              plugin.text().of(p, "restricted-prices", Util.getItemStackName(shop.getItem()), Component.text(priceCheckResult.getMin()), Component.text(priceCheckResult.getMax())).send();
+              plugin.text().of(p, "price-too-high", maxFormatted).send();
+      case PRICE_RESTRICTED -> {
+        if(min > 0 && max >= 0) {
+          plugin.text().of(p, "restricted-prices", Util.getItemStackName(shop.getItem()), minFormatted, maxFormatted).send();
+        } else if(min > 0) {
+          plugin.text().of(p, "restricted-price-min", Util.getItemStackName(shop.getItem()), minFormatted).send();
+        } else {
+          plugin.text().of(p, "restricted-price-max", Util.getItemStackName(shop.getItem()), maxFormatted).send();
+        }
+      }
       case NOT_VALID -> plugin.text().of(p, "not-a-number", shop.getPrice()).send();
       case NOT_A_WHOLE_NUMBER -> plugin.text().of(p, "not-a-integer", shop.getPrice()).send();
       case PASS -> {
@@ -823,7 +839,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
         if(createCost > 0) {
           final QSEconomyTransaction economyTransaction = QSEconomyTransaction.builder().taxer(cacheTaxAccount).from(QUserImpl.createFullFilled(p)).to(null).amount(BigDecimal.valueOf(createCost)).currency(plugin.getCurrency()).world(shop.bukkitLocation().getWorld().getName()).build();
           if(!economyTransaction.completable()) {
-            plugin.text().of(p, "you-cant-afford-a-new-shop", format(createCost, shop.bukkitLocation().getWorld(), shop.getCurrency())).send();
+            plugin.text().of(p, "you-cant-afford-a-new-shop", format(createCost, shop)).send();
             return;
           }
           if(!economyTransaction.safeCommit()) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -39,7 +39,9 @@ import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapper;
 import com.ghostchu.quickshop.util.logger.Log;
 import lombok.Data;
 import net.kyori.adventure.text.Component;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.entity.Player;
@@ -197,20 +199,32 @@ public class ShopUtil {
     }
 
     final PriceLimiterCheckResult checkResult = limiter.check(user, shop.getItem(), plugin.getCurrency(), price);
+    final String currency = (shop.getCurrency() == null)? ((plugin.getCurrency() == null)? "" : plugin.getCurrency()) : shop.getCurrency();
+    final World world = shop.bukkitLocation().getWorld();
+    final EconomyProvider econ = plugin.getEconomyManager().provider();
+
+    final double min = checkResult.getMin();
+    final double max = checkResult.getMax();
+    final String minFormatted = econ != null? econ.format(BigDecimal.valueOf(min), world.getName(), currency) : String.valueOf(min);
+    final String maxFormatted = econ != null? econ.format(BigDecimal.valueOf(max), world.getName(), currency) : String.valueOf(max);
 
     switch(checkResult.getStatus()) {
       case PRICE_RESTRICTED -> {
-        plugin.text().of(user.getUniqueId(), "restricted-prices", Util.getItemStackName(shop.getItem()),
-                         Component.text(checkResult.getMin()),
-                         Component.text(checkResult.getMax())).send();
+        if (min > 0 && max >= 0) {
+          plugin.text().of(user.getUniqueId(), "restricted-prices", Util.getItemStackName(shop.getItem()), minFormatted, maxFormatted).send();
+        } else if (min > 0) {
+          plugin.text().of(user.getUniqueId(), "restricted-price-min", Util.getItemStackName(shop.getItem()), minFormatted).send();
+        } else {
+          plugin.text().of(user.getUniqueId(), "restricted-price-max", Util.getItemStackName(shop.getItem()), maxFormatted).send();
+        }
         return;
       }
       case REACHED_PRICE_MIN_LIMIT -> {
-        plugin.text().of(user, "price-too-cheap", (format)? MsgUtil.decimalFormat(checkResult.getMin()) : Double.toString(checkResult.getMin())).send();
+        plugin.text().of(user, "price-too-cheap", minFormatted).send();
         return;
       }
       case REACHED_PRICE_MAX_LIMIT -> {
-        plugin.text().of(user, "price-too-high", (format)? MsgUtil.decimalFormat(checkResult.getMax()) : Double.toString(checkResult.getMax())).send();
+        plugin.text().of(user, "price-too-high", maxFormatted).send();
         return;
       }
       case NOT_A_WHOLE_NUMBER -> {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -161,6 +161,18 @@ public class ShopUtil {
     QuickShop.getInstance().text().of(receiverQUser, "transfer-single-ask", 60).send();
   }
 
+  //check if the price will fit within DECIMAL(32,2)
+  public static boolean isValidPrice(final BigDecimal price) {
+
+    //At most 2 decimal places
+    if (price.scale() > 2) {
+      return false;
+    }
+
+    //max 32 total digits
+    return price.precision() <= 32;
+  }
+
   public static void setPrice(final QuickShop plugin, @NotNull final QUser user, final double price, @NotNull final Shop shop) {
 
     if(user.getUniqueId() == null || user.getBukkitPlayer().isEmpty()) {
@@ -189,9 +201,15 @@ public class ShopUtil {
       return;
     }
 
+    final BigDecimal priceBigDecimal = BigDecimal.valueOf(price);
+    if(!isValidPrice(priceBigDecimal)) {
+      plugin.text().of(user, "digits-reach-the-limit", Component.text(32)).send();
+      return;
+    }
+
     final int maximumDigitsInPrice = plugin.getConfig().getInt("shop.maximum-digits-in-price", -1);
     if(maximumDigitsInPrice != -1) {
-      final int inputScale = Math.max(BigDecimal.valueOf(price).stripTrailingZeros().scale(), 0);
+      final int inputScale = Math.max(priceBigDecimal.stripTrailingZeros().scale(), 0);
       if(inputScale > maximumDigitsInPrice) {
         plugin.text().of(user, "digits-reach-the-limit", Component.text(maximumDigitsInPrice)).send();
         return;

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -450,7 +450,7 @@ support-disable-reason:
 supertool-is-disabled: <red>Super tool is disabled. Cannot break any shops.
 unknown-owner: Unknown
 restricted-prices: '<red>Restricted price for {0}: Min {1}, Max {2}'
-estricted-price-max: '<red>Restricted price for {0}: Max {1}'
+restricted-price-max: '<red>Restricted price for {0}: Max {1}'
 restricted-price-min: '<red>Restricted price for {0}: Min {1}'
 nearby-shop-this-way: <green>Shop is {0} block(s) away from you.
 owner-bypass-check: <yellow>Bypassed all checks. Trade successful! (You are now the

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -449,7 +449,9 @@ support-disable-reason:
     Fukkit, Cardboard, etc.
 supertool-is-disabled: <red>Super tool is disabled. Cannot break any shops.
 unknown-owner: Unknown
-restricted-prices: '<red>Restricted price for {0}: Min {1}, max {2}'
+restricted-prices: '<red>Restricted price for {0}: Min {1}, Max {2}'
+estricted-price-max: '<red>Restricted price for {0}: Max {1}'
+restricted-price-min: '<red>Restricted price for {0}: Min {1}'
 nearby-shop-this-way: <green>Shop is {0} block(s) away from you.
 owner-bypass-check: <yellow>Bypassed all checks. Trade successful! (You are now the
   shop owner!)

--- a/quickshop-bukkit/src/main/resources/price-restriction.yml
+++ b/quickshop-bukkit/src/main/resources/price-restriction.yml
@@ -2,7 +2,7 @@ version: 3
 whole-number-only: false  # This option not control by enable option, always enabled
 undefined: # This option not control by enable option, always enabled
   min: 0.01 # Can be zero if you want player create a free shop
-  max: -1 # This can be up to 1.7976931348623157E308, or -1 to disable maximum price.
+  max: 999999999999999999999999999.99 # This can be up to 1.7976931348623157E308, or -1 to disable maximum price.
 enable: false
 rules: # Rules set
   example: # Rules name, used for identifier and permission node (quickshop.price.restriction.bypass.<name>)

--- a/quickshop-bukkit/src/main/resources/price-restriction.yml
+++ b/quickshop-bukkit/src/main/resources/price-restriction.yml
@@ -2,7 +2,7 @@ version: 3
 whole-number-only: false  # This option not control by enable option, always enabled
 undefined: # This option not control by enable option, always enabled
   min: 0.01 # Can be zero if you want player create a free shop
-  max: 999999999999999999999999999.99 # Actually this can be up to 1.7976931348623157E308
+  max: -1 # This can be up to 1.7976931348623157E308, or -1 to disable maximum price.
 enable: false
 rules: # Rules set
   example: # Rules name, used for identifier and permission node (quickshop.price.restriction.bypass.<name>)


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

This PR fixes the #1765 PR.

From that PR:

"Only display both min and max price messages if there is a min and max price set. Otherwise, just display one or the other.
Don't decimal format price restriction messages as you may lose required granularity."

---

## Type of Change

* [ ] Feature
* [X] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [ ] I have tested these changes locally
* [X] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---