### PR TITLE
Use item_name if present if force-use-item-original-name is on

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -926,20 +926,20 @@ public class Util {
   @Nullable
   public static Component getItemCustomName(@NotNull final ItemStack itemStack, final String locale) {
 
+    final ItemMeta meta = itemStack.getItemMeta();
     if(useEnchantmentForEnchantedBook() && itemStack.getType() == Material.ENCHANTED_BOOK) {
-      final ItemMeta meta = itemStack.getItemMeta();
       if(meta instanceof final EnchantmentStorageMeta enchantmentStorageMeta && enchantmentStorageMeta.hasStoredEnchants()) {
         return getFirstEnchantmentName(enchantmentStorageMeta);
       }
     }
 
-    if(usePotionForPotionItem() && itemStack.getItemMeta() instanceof PotionMeta) {
+    if(usePotionForPotionItem() && meta instanceof PotionMeta) {
 
       return getFirstPotionEffectName(itemStack, locale);
     }
 
 
-    if(!itemStack.hasItemMeta() || QuickShop.getInstance().getConfig().getBoolean("shop.force-use-item-original-name")) {
+    if(meta == null) {
 
       return null;
     }
@@ -947,14 +947,23 @@ public class Util {
     boolean itemName = false;
 
     try {
-      itemName = Objects.requireNonNull(itemStack.getItemMeta()).hasItemName();
+      itemName = meta.hasItemName();
     } catch(final NoSuchMethodError ignore) {
       //outdated
     }
 
-    if(Objects.requireNonNull(itemStack.getItemMeta()).hasDisplayName() || itemName) {
+    if(QuickShop.getInstance().getConfig().getBoolean("shop.force-use-item-original-name")) {
 
-      return plugin.platform().getDisplayName(itemStack.getItemMeta());
+      try {
+        return itemName ? meta.itemName() : null;
+      } catch(final NoSuchMethodError ignored) {}
+
+      return null;
+    }
+
+    if(meta.hasDisplayName() || itemName) {
+
+      return plugin.platform().getDisplayName(meta);
     }
     return null;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

Allows text from the item_name component to be used as the item name on the shop sign & elsewhere when force-use-item-original-name is enabled, for supporting custom items.

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---