### PR TITLE
Fix partial items being able to be overridden in remove operation

### DIFF
--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/inventory/InventoryWrapper.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/inventory/InventoryWrapper.java
@@ -185,7 +185,6 @@ public interface InventoryWrapper extends Iterable<ItemStack> {
 
       final ItemStack requested = itemStacks[i];
       int remaining = requested.getAmount();
-      int removedAmount = 0;
 
       final InventoryWrapperIterator iterator = iterator();
 
@@ -212,12 +211,9 @@ public interface InventoryWrapper extends Iterable<ItemStack> {
         iterator.setCurrent(current);
 
         remaining -= amount;
-        removedAmount += amount;
         if (amount > 0) {
 
-          final ItemStack removedStack = requested.clone();
-          removedStack.setAmount(amount);
-          removed.put(iteratorSlot, currentClone);
+          removed.merge(iteratorSlot, currentClone, (existing, added) -> existing.add(added.getAmount()));
         }
         iteratorSlot++;
       }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/operation/RemoveItemOperation.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/operation/RemoveItemOperation.java
@@ -4,7 +4,6 @@ import com.ghostchu.quickshop.api.inventory.InventoryWrapper;
 import com.ghostchu.quickshop.api.inventory.ItemRemoveResult;
 import com.ghostchu.quickshop.api.operation.Operation;
 import com.ghostchu.quickshop.api.operation.result.ItemRemoveOperationResult;
-import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logger.Log;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +36,7 @@ public class RemoveItemOperation implements Operation {
     this.item = item.clone();
     this.amount = amount;
     this.inv = inv;
-    this.itemMaxStackSize = Util.getItemMaxStackSize(item.getType());
+    this.itemMaxStackSize = item.getMaxStackSize();
 
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/operation/RemoveItemOperation.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/operation/RemoveItemOperation.java
@@ -9,7 +9,8 @@ import com.ghostchu.quickshop.util.logger.Log;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Operation to remove items
@@ -46,30 +47,25 @@ public class RemoveItemOperation implements Operation {
     committed = true;
     this.snapshot = inv.createSnapshot();
     int remains = amount;
-    int lastRemains = -1;
 
-    final ItemRemoveResult result = new ItemRemoveResult(new HashMap<>(), new HashMap<>());
+    final List<ItemStack> itemsToRemove = new ArrayList<>();
 
     while(remains > 0) {
       final int stackSize = Math.min(remains, itemMaxStackSize);
-      item.setAmount(stackSize);
-      Log.debug("Committing remove item operation, remains: " + remains + ", stackSize: " + stackSize + ", target: " + item);
+      remains -= stackSize;
 
-      final ItemRemoveResult resultNotFit = inv.removeItem(item.clone());
-      result.leftovers().putAll(resultNotFit.leftovers());
-      result.removed().putAll(resultNotFit.removed());
-      if(resultNotFit.leftovers().isEmpty()) {
-        remains -= stackSize;
-      } else {
-        remains -= stackSize - resultNotFit.leftovers().entrySet().iterator().next().getValue().getAmount();
-      }
+      final ItemStack clone = item.clone();
+      clone.setAmount(stackSize);
 
-      if(remains == lastRemains) {
-        return new ItemRemoveOperationResult(false, result);
-      }
-      lastRemains = remains;
+      itemsToRemove.add(clone);
     }
-    return new ItemRemoveOperationResult(true, result);
+
+    Log.debug("Committing remove item operation, target: " + itemsToRemove);
+
+    final ItemRemoveResult result = inv.removeItem(itemsToRemove.toArray(new ItemStack[0]));
+
+    Log.debug("Remove item operation results, leftover: " + result.leftovers() + ", removed: " + result.removed());
+    return new ItemRemoveOperationResult(result.leftovers().isEmpty(), result);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

Fixes an issue where the ItemRemoveResult#removed map could have some elements overridden when encountering mixed stack sizes, this was caused by the map being improperly merged using putAll during iterations.

Reproduced it with this setup, shop stack size of 64:
<img width="206" height="98" alt="Screenshot 2026-06-22 152807" src="https://github.com/user-attachments/assets/0a79707b-0303-4daa-b720-7336cc6fecd6" />


Then, when purchasing 2 bulks, the plugin attempts to remove 64 diamond blocks twice, with these results:
{0=ItemStack{DIAMOND_BLOCK x 32}, 1=ItemStack{DIAMOND_BLOCK x 32}}
{1=ItemStack{DIAMOND_BLOCK x 32}, 2=ItemStack{DIAMOND_BLOCK x 32}}

when you putAll these maps together, you end up with
{0=ItemStack{DIAMOND_BLOCK x 32}, 1=ItemStack{DIAMOND_BLOCK x 32}, 2=ItemStack{DIAMOND_BLOCK x 32}}
which has less total items due to the item with key 1 being overridden by the other one instead of being merged.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

This currently doesn't impact anyone since ItemRemoveResult#removed isn't used yet, it's only used by the not yet added functionality where the items you receive are the exact ones that got removed.

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---