### PR TITLE
Hide enchantment level if 1 is the max

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -1066,7 +1066,12 @@ public class Util {
       name = MsgUtil.setHandleFailedHover(null, Component.text(enchantment.getKey().getKey()));
       plugin.logger().warn("Failed to handle translation for Enchantment {}", enchantment.getKey(), throwable);
     }
-    name = name.append(Component.text(" " + RomanNumber.toRoman(level)));
+
+    if(enchantment.getMaxLevel() > 1 || level > 1) {
+
+      name = name.append(Component.text(" " + RomanNumber.toRoman(level)));
+    }
+
     return name;
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
Matches how the game displays enchantments when the max level is 1, mending 1 is now displayed as "Mending" while mending 2 still shows "Mending II"

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---