### PR TITLE
Improve efficiency of towny compat shop purging

### DIFF
--- a/compatibility/towny/src/main/java/com/ghostchu/quickshop/compatibility/towny/Main.java
+++ b/compatibility/towny/src/main/java/com/ghostchu/quickshop/compatibility/towny/Main.java
@@ -58,9 +58,11 @@ import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -272,10 +274,26 @@ public final class Main extends CompatibilityModule implements Listener {
     Util.asyncThreadRun(()->{
       final QUser actor = QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "Towny", false);
       //Getting all shop with world-chunk-shop mapping
-      for(final Shop shop : api.getShopManager().getAllShops()) {
-        if(!worldCoords.contains(WorldCoord.parseWorldCoord(shop.bukkitLocation()))) {
-          continue;
+      final List<Shop> shops = new ArrayList<>();
+      if(WorldCoord.getCellSize() != 16) {
+
+        for(final Shop shop : api.getShopManager().getAllShops()) {
+          if(!worldCoords.contains(WorldCoord.parseWorldCoord(shop.bukkitLocation()))) {
+            continue;
+          }
+          shops.add(shop);
         }
+      } else {
+        // the size of a worldcoord is the same size as a chunk, we can use a faster way to retrieve all shops
+        for(final WorldCoord worldCoord : worldCoords) {
+          final Map<Location, Shop> shopsInChunk = api.getShopManager().getShops(worldCoord.getWorldName(), worldCoord.getX(), worldCoord.getZ());
+          if(!shopsInChunk.isEmpty()) {
+            shops.addAll(shopsInChunk.values());
+          }
+        }
+      }
+
+      for(final Shop shop : shops) {
         if(overrideOwner || owner != null && owner.equals(shop.getOwner().getUniqueId())) {
           Util.regionThread(shop.bukkitLocation(), ()->{
             recordDeletion(actor, shop, reason);


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
If the worldcoord size is 16 then it's the same size as a chunk, and means that shops can be directly looked up based on that instead of checking all shops in existence.

---

## Type of Change

* [ ] Feature
* [ ] Bug fix
* [x] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---