### PR TITLE
Fix ShopBenefitAddEvent not showing the cancel message

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Benefit.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Benefit.java
@@ -103,8 +103,7 @@ public class SubCommand_Benefit implements CommandHandler<Player> {
           event = event.clone(Phase.MAIN);
           if(event.callCancellableEvent()) {
 
-            plugin.logger().info("Plugin cancelled ShopBenefitAddEvent");
-            plugin.text().of(sender, "internal-error").send();
+            plugin.text().of(sender, "plugin-cancelled", event.getCancelReason());
             return;
           }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Benefit.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Benefit.java
@@ -103,7 +103,7 @@ public class SubCommand_Benefit implements CommandHandler<Player> {
           event = event.clone(Phase.MAIN);
           if(event.callCancellableEvent()) {
 
-            plugin.text().of(sender, "plugin-cancelled", event.getCancelReason());
+            plugin.text().of(sender, "plugin-cancelled", event.getCancelReason()).send();
             return;
           }
 
@@ -164,8 +164,7 @@ public class SubCommand_Benefit implements CommandHandler<Player> {
               event = event.clone(Phase.MAIN);
               if(event.callCancellableEvent()) {
 
-                plugin.logger().info("Plugin cancelled ShopBenefitRemoveEvent");
-                plugin.text().of(sender, "internal-error").send();
+                plugin.text().of(sender, "plugin-cancelled", event.getCancelReason()).send();
                 return;
               }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -257,6 +257,7 @@ public class ShopUtil {
 
     if(event.callCancellableEvent()) {
       Log.debug("A plugin cancelled the price change event.");
+      plugin.text().of(user, "plugin-cancelled", event.getCancelReason()).send();
       return;
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
Fixes a generic internal error message being shown instead of the reason provided by the plugin that cancelled the event

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [ ] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---