### PR TITLE
Use async stock fetching in UIs to improve accuracy and ensure up-to-date display. Add axolotyl and tropical fish variants to fish_bucket custom matcher component.

### DIFF
--- a/.changelog/SNAPSHOTS/6.3.0.0-SNAPSHOT-11.md
+++ b/.changelog/SNAPSHOTS/6.3.0.0-SNAPSHOT-11.md
@@ -1,0 +1,12 @@
+# 6.3.0.0 (Orion: Rigel) SNAPSHOT 11
+
+## Minor Changes
+- Modified fish_bucket custom matcher component to include the following components:
+  - "AXOLOTL/VARIANT",
+  - "SALMON/SIZE",
+  - "TROPICAL_FISH/PATTERN",
+  - "TROPICAL_FISH/BASE_COLOR",
+  - "TROPICAL_FISH/BASE_COLOR"
+
+## Internal Changes
+- Adjusted trade ui to use a stock variable instead of the cache, this should fix issues where stock information was sometimes inaccurate while not sacrificing performance.

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/ShopKeeperMenu.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/ShopKeeperMenu.java
@@ -33,6 +33,7 @@ public class ShopKeeperMenu extends QuickShopMenu {
   public static final int KEEPER_MAIN = 1;
 
   public static final String SHOP_DATA_ID = "SHOP_ID";
+  public static final String SHOP_STOCK_ID = "SHOP_STOCK_REMAINING";
 
   public ShopKeeperMenu() {
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/trade/MainPage.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/trade/MainPage.java
@@ -51,6 +51,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.ghostchu.quickshop.menu.ShopKeeperMenu.SHOP_STOCK_ID;
+
 /**
  * MainPage
  *
@@ -104,9 +106,22 @@ public class MainPage extends QuickShopPage {
 
         final ItemStack shopItem = shop.get().getItem();
         final int amount = shopItem.getAmount();
-        // Use cache to avoid Folia cross-region block access issues
-        final int stock = (shop.get().isBuying())? -1 : MarketUtils.getStockFromCache(shop.get());
-        final String stockString = (shop.get().isUnlimited())? "Unlimited" : stock + "";
+
+        final int remainingStock = (int)viewer.get().dataOrDefault(SHOP_STOCK_ID, MarketUtils.getStockFromCache(shop.get()));
+        final QuickShop plugin = QuickShop.getInstance();
+        final String baseKey = (shop.get().isStackingShop())? shop.get().shopType().stackTradingTranslationKey()
+                                                            : shop.get().shopType().tradingTranslationKey();
+        final String finalKey = (shop.get().shopState().overrideShopTypeText())? shop.get().shopState().translationKey() : baseKey;
+
+        final Component stockComponent = switch (remainingStock) {
+
+          case -1 -> plugin.text().of(player, finalKey, plugin.text().of(player, "signs.unlimited").forLocale()).forLocale();
+
+          case 0 -> (shop.get().shopState().overrideShopTypeText())? plugin.text().of(player, shop.get().shopState().translationKey()).forLocale()
+                                                                   : plugin.text().of(player, shop.get().shopType().outOfStockTranslationKey()).forLocale();
+
+          default -> Component.text(remainingStock);
+        };
         final String priceFormatted = shop.get().format(shop.get().bukkitLocation().getWorld().getName(), shop.get().getCurrency());
 
         // Shop item display slot from config (centered in row 2)
@@ -130,7 +145,7 @@ public class MainPage extends QuickShopPage {
         final int infoStockSlot = (infoStockConfig != null)? infoStockConfig.getSlot() : 21;
         open.getPage().addIcon(new IconBuilder(QuickShop.getInstance().stack().of(infoStockMaterial, 1)
                                                        .customName(getConfigDisplay(id, infoStockConfig, "<yellow>Stock Information</yellow>"))
-                                                       .lore(getConfigLore(id, infoStockConfig, stockString)))
+                                                       .lore(getConfigLore(id, infoStockConfig, stockComponent)))
                                        .withSlot(infoStockSlot).build());
 
         // Info icons row - Price info
@@ -163,7 +178,7 @@ public class MainPage extends QuickShopPage {
         final String enterPath = (shop.get().isSelling())? "trade.enter-buy" : "trade.enter-sell";
         open.getPage().addIcon(new IconBuilder(QuickShop.getInstance().stack().of(customAmountMaterial, 1)
                                                        .customName(getConfigDisplay(id, customAmountConfig, "<bold><blue>Custom Order</blue></bold>"))
-                                                       .lore(getConfigLore(id, customAmountConfig, amount, stockString)))
+                                                       .lore(getConfigLore(id, customAmountConfig, amount, stockComponent)))
                                        .withActions(new GuiChatAction((message)->{
                                          if(!message.isEmpty()) {
                                            try {
@@ -173,7 +188,7 @@ public class MainPage extends QuickShopPage {
                                                return true;
                                              }
 
-                                             if(!shop.get().isUnlimited() && quantity > stock && stock > -1) {
+                                             if(!shop.get().isUnlimited() && quantity > remainingStock && remainingStock > -1) {
                                                player.sendMessage(guiMessage("trade.invalid-stock"));
                                                return true;
                                              }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/interaction/behaviors/ControlPanelUI.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/interaction/behaviors/ControlPanelUI.java
@@ -38,6 +38,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * ControlPanelUI
  *
@@ -78,10 +80,15 @@ public class ControlPanelUI implements InteractionBehavior {
     if(group.equalsIgnoreCase(BuiltInShopPermissionGroup.STAFF.getNamespacedNode())
        || group.equalsIgnoreCase(BuiltInShopPermissionGroup.ADMINISTRATOR.getNamespacedNode())) {
 
-      MenuManager.instance().addViewer(viewer);
 
-      final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(event.getPlayer());
-      MenuManager.instance().open("qs:keeper", 1, menuPlayer);
+      final CompletableFuture<Integer> remainingStockFuture = shop.shopType().remainingStockAsync(shop);
+      remainingStockFuture.thenAccept(remainingStock ->{
+        viewer.addData(ShopKeeperMenu.SHOP_STOCK_ID, remainingStock);
+        MenuManager.instance().addViewer(viewer);
+
+        final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(event.getPlayer());
+        MenuManager.instance().open("qs:keeper", 1, menuPlayer);
+      });
 
       event.setCancelled(true);
       event.setUseInteractedBlock(Event.Result.DENY);
@@ -100,10 +107,16 @@ public class ControlPanelUI implements InteractionBehavior {
       return;
     }
 
-    MenuManager.instance().addViewer(viewer);
 
-    final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(event.getPlayer());
-    MenuManager.instance().open("qs:trade", 1, menuPlayer);
+    final CompletableFuture<Integer> remainingStockFuture = shop.shopType().remainingStockAsync(shop);
+    remainingStockFuture.thenAccept(remainingStock ->{
+      viewer.addData(ShopKeeperMenu.SHOP_STOCK_ID, remainingStock);
+
+      MenuManager.instance().addViewer(viewer);
+
+      final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(event.getPlayer());
+      MenuManager.instance().open("qs:trade", 1, menuPlayer);
+    });
 
 
     event.setCancelled(true);
@@ -141,10 +154,17 @@ public class ControlPanelUI implements InteractionBehavior {
     if(group.equalsIgnoreCase(BuiltInShopPermissionGroup.STAFF.getNamespacedNode())
        || group.equalsIgnoreCase(BuiltInShopPermissionGroup.ADMINISTRATOR.getNamespacedNode())) {
 
-      MenuManager.instance().addViewer(viewer);
 
-      final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(player);
-      MenuManager.instance().open("qs:keeper", 1, menuPlayer);
+      final CompletableFuture<Integer> remainingStockFuture = shop.shopType().remainingStockAsync(shop);
+      remainingStockFuture.thenAccept(remainingStock ->{
+
+        viewer.addData(ShopKeeperMenu.SHOP_STOCK_ID, remainingStock);
+
+        MenuManager.instance().addViewer(viewer);
+
+        final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(player);
+        MenuManager.instance().open("qs:keeper", 1, menuPlayer);
+      });
       return;
     }
 
@@ -159,9 +179,15 @@ public class ControlPanelUI implements InteractionBehavior {
       return;
     }
 
-    MenuManager.instance().addViewer(viewer);
+    final CompletableFuture<Integer> remainingStockFuture = shop.shopType().remainingStockAsync(shop);
+    remainingStockFuture.thenAccept(remainingStock ->{
 
-    final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(player);
-    MenuManager.instance().open("qs:trade", 1, menuPlayer);
+      viewer.addData(ShopKeeperMenu.SHOP_STOCK_ID, remainingStock);
+
+      MenuManager.instance().addViewer(viewer);
+
+      final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(player);
+      MenuManager.instance().open("qs:trade", 1, menuPlayer);
+    });
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/interaction/behaviors/TradeUI.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/interaction/behaviors/TradeUI.java
@@ -38,6 +38,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * TradeUI
  *
@@ -93,12 +95,18 @@ public class TradeUI implements InteractionBehavior {
         return;
       }
 
-      final MenuViewer viewer = new MenuViewer(event.getPlayer().getUniqueId());
-      viewer.addData(ShopKeeperMenu.SHOP_DATA_ID, shop.getShopId());
-      MenuManager.instance().addViewer(viewer);
+      final CompletableFuture<Integer> remainingStockFuture = shop.shopType().remainingStockAsync(shop);
+      remainingStockFuture.thenAccept(remainingStock -> {
 
-      final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(event.getPlayer());
-      MenuManager.instance().open("qs:trade", 1, menuPlayer);
+
+        final MenuViewer viewer = new MenuViewer(event.getPlayer().getUniqueId());
+        viewer.addData(ShopKeeperMenu.SHOP_DATA_ID, shop.getShopId());
+        viewer.addData(ShopKeeperMenu.SHOP_STOCK_ID, remainingStock);
+        MenuManager.instance().addViewer(viewer);
+
+        final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(event.getPlayer());
+        MenuManager.instance().open("qs:trade", 1, menuPlayer);
+      });
 
       //cancel our item use
       event.setCancelled(true);
@@ -141,12 +149,17 @@ public class TradeUI implements InteractionBehavior {
       return;
     }
 
-    final MenuViewer viewer = new MenuViewer(player.getUniqueId());
-    viewer.addData(ShopKeeperMenu.SHOP_DATA_ID, shop.getShopId());
-    MenuManager.instance().addViewer(viewer);
+    final CompletableFuture<Integer> remainingStockFuture = shop.shopType().remainingStockAsync(shop);
+    remainingStockFuture.thenAccept(remainingStock ->{
 
-    final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(player);
-    MenuManager.instance().open("qs:trade", 1, menuPlayer);
+      final MenuViewer viewer = new MenuViewer(player.getUniqueId());
+      viewer.addData(ShopKeeperMenu.SHOP_DATA_ID, shop.getShopId());
+      viewer.addData(ShopKeeperMenu.SHOP_STOCK_ID, remainingStock);
+      MenuManager.instance().addViewer(viewer);
+
+      final MenuPlayer menuPlayer = QuickShop.getInstance().createMenuPlayer(player);
+      MenuManager.instance().open("qs:trade", 1, menuPlayer);
+    });
 
     //cancel our item use
     event.setCancelled(true);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/matcher/item/ModernCustomMatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/matcher/item/ModernCustomMatcher.java
@@ -258,7 +258,12 @@ public class ModernCustomMatcher implements ItemMatcher, Reloadable {
 
       // Fish bucket entity data
       case "fish_bucket" -> add(out, registry,
-                                "BUCKET_ENTITY_DATA"
+                                "BUCKET_ENTITY_DATA",
+                                "AXOLOTL/VARIANT",
+                                "SALMON/SIZE",
+                                "TROPICAL_FISH/PATTERN",
+                                "TROPICAL_FISH/BASE_COLOR",
+                                "TROPICAL_FISH/BASE_COLOR"
                                );
 
       // Suspicious stew effects

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/matcher/item/ModernCustomMatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/matcher/item/ModernCustomMatcher.java
@@ -256,7 +256,7 @@ public class ModernCustomMatcher implements ItemMatcher, Reloadable {
                                   "DYED_COLOR"
                                  );
 
-      // Fish bucket entity data
+      // Fish bucket entity data, and various fish variants
       case "fish_bucket" -> add(out, registry,
                                 "BUCKET_ENTITY_DATA",
                                 "AXOLOTL/VARIANT",


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

## Minor Changes
- Modified fish_bucket custom matcher component to include the following components:
  - "AXOLOTL/VARIANT",
  - "SALMON/SIZE",
  - "TROPICAL_FISH/PATTERN",
  - "TROPICAL_FISH/BASE_COLOR",
  - "TROPICAL_FISH/BASE_COLOR"

## Internal Changes
- Adjusted trade ui to use a stock variable instead of the cache, this should fix issues where stock information was sometimes inaccurate while not sacrificing performance.

---

## Type of Change

* [X] Feature
* [X] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---