### PR TITLE
Fix shop preview locales being sticky

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -96,6 +96,7 @@ import com.ghostchu.quickshop.util.envcheck.EnvCheckEntry;
 import com.ghostchu.quickshop.util.envcheck.EnvironmentChecker;
 import com.ghostchu.quickshop.util.envcheck.ResultContainer;
 import com.ghostchu.quickshop.util.envcheck.ResultReport;
+import com.ghostchu.quickshop.util.holder.QuickShopPreviewGUIHolder;
 import com.ghostchu.quickshop.util.logger.Log;
 import com.ghostchu.quickshop.util.matcher.item.BukkitItemMatcherImpl;
 import com.ghostchu.quickshop.util.matcher.item.ModernCustomMatcher;
@@ -153,7 +154,9 @@ import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.ServicePriority;
 import org.h2.Driver;
@@ -1341,6 +1344,17 @@ public class QuickShop implements QuickShopAPI, Reloadable {
       logger.info("Cleaning up shop manager...");
       shopManager.clear();
     }
+
+    try {
+      for (final Player player : javaPlugin.getServer().getOnlinePlayers()) {
+        if (player.getOpenInventory().getTopInventory().getHolder(false) instanceof QuickShopPreviewGUIHolder) {
+          player.closeInventory(InventoryCloseEvent.Reason.PLUGIN);
+        }
+      }
+    } catch(Exception e) {
+      javaPlugin.getSLF4JLogger().warn("An exception occurred while attempting to close open preview inventories for players", e);
+    }
+
     if(AbstractDisplayItem.getNowUsing() == DisplayType.VIRTUALITEM && displayManager != null) {
       logger.info("Cleaning up display manager...");
       displayManager.unload();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -156,7 +156,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
-import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.ServicePriority;
 import org.h2.Driver;
@@ -1348,7 +1347,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     try {
       for (final Player player : javaPlugin.getServer().getOnlinePlayers()) {
         if (player.getOpenInventory().getTopInventory().getHolder(false) instanceof QuickShopPreviewGUIHolder) {
-          player.closeInventory(InventoryCloseEvent.Reason.PLUGIN);
+          player.closeInventory();
         }
       }
     } catch(Exception e) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -135,8 +135,6 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
   @EqualsAndHashCode.Exclude
   private volatile boolean createBackup = false;
   @EqualsAndHashCode.Exclude
-  private InventoryPreview inventoryPreview = null;
-  @EqualsAndHashCode.Exclude
   private boolean dirty;
   @EqualsAndHashCode.Exclude
   private boolean updating = false;
@@ -528,11 +526,6 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
     }
     this.displayItem = null;
     checkDisplay();
-    if(this.inventoryPreview != null) {
-
-      this.inventoryPreview.close();
-      this.inventoryPreview = null;
-    }
     setSignText();
     setDirty();
   }
@@ -1562,9 +1555,6 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
       Log.debug("Dupe unload request, canceled.");
       return;
     }
-    if(inventoryPreview != null) {
-      inventoryPreview.close();
-    }
     if(this.displayItem != null) {
       this.displayItem.remove(dontTouchWorld);
     }
@@ -1576,10 +1566,7 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
   @Override
   public void openPreview(@NotNull final Player player) {
 
-    if(inventoryPreview == null) {
-      inventoryPreview = new InventoryPreview(plugin, getItem().clone(), player.getLocale());
-    }
-    inventoryPreview.show(player);
+    InventoryPreview.show(player, getItem());
 
   }
 
@@ -2139,7 +2126,6 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
            ", displayItem=" + displayItem +
            ", isLoaded=" + isLoaded +
            ", createBackup=" + createBackup +
-           ", inventoryPreview=" + inventoryPreview +
            ", dirty=" + dirty +
            ", updating=" + updating +
            ", currency='" + currency + '\'' +

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/InventoryPreview.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/InventoryPreview.java
@@ -2,110 +2,78 @@ package com.ghostchu.quickshop.shop;
 
 import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.event.inventory.ShopInventoryPreviewEvent;
-import com.ghostchu.quickshop.common.util.CommonUtil;
 import com.ghostchu.quickshop.shop.datatype.PreviewGuiPersistentDataType;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.holder.QuickShopPreviewGUIHolder;
 import com.ghostchu.quickshop.util.logger.Log;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 /**
  * A class to create a GUI item preview quickly
  */
-@EqualsAndHashCode
-@ToString
-public class InventoryPreview implements Listener {
+public class InventoryPreview {
 
   private static final NamespacedKey NAMESPACED_KEY = new NamespacedKey(QuickShop.getInstance().getJavaPlugin(), "preview-item");
-  private final ItemStack itemStack;
-  private final QuickShop plugin = QuickShop.getInstance();
-  private String previewStr;
-  @Nullable
-  private Inventory inventory;
 
-  /**
-   * Create a preview item GUI.
-   *
-   * @param itemStack The item you want create.
-   * @param plugin    The plugin instance.
-   */
-  public InventoryPreview(@NotNull final QuickShop plugin, @NotNull final ItemStack itemStack, @NotNull final String locale) {
-
-    Util.ensureThread(false);
-    this.itemStack = itemStack.clone();
-    final ItemMeta itemMeta;
-    if(itemStack.hasItemMeta()) {
-      itemMeta = this.itemStack.getItemMeta();
-    } else {
-      itemMeta = Bukkit.getItemFactory().getItemMeta(itemStack.getType());
-    }
-    previewStr = plugin.text().of("quickshop-gui-preview").legacy(locale);
-    if(CommonUtil.isEmptyString(previewStr)) {
-      previewStr = ChatColor.RED + "FIXME: Do not set quickshop-gui-preview to null or empty string.";
-    }
-    if(itemMeta != null) {
-      if(itemMeta.hasLore()) {
-        itemMeta.getLore().add(previewStr);
-      } else {
-        itemMeta.setLore(Collections.singletonList(previewStr));
-      }
-
-      itemMeta.getPersistentDataContainer().set(NAMESPACED_KEY, PreviewGuiPersistentDataType.INSTANCE, UUID.randomUUID());
-      this.itemStack.setItemMeta(itemMeta);
-    }
-  }
-
-  public void close() {
-
-    Util.ensureThread(false);
-    if(inventory == null) {
-      return;
-    }
-
-    for(final HumanEntity player : new ArrayList<>(inventory.getViewers())) {
-      player.closeInventory();
-    }
-    inventory = null; // Destroy
-  }
+  private InventoryPreview() {}
 
   /**
    * Open the preview GUI for player.
    */
-  public void show(final Player player) {
+  public static void show(final Player player, ItemStack itemStack) {
 
     Util.ensureThread(false);
     if(itemStack == null || player == null || player.isSleeping()) // Null pointer exception
     {
       return;
     }
+
+    itemStack = itemStack.clone();
     final ShopInventoryPreviewEvent shopInventoryPreview = new ShopInventoryPreviewEvent(player, itemStack);
     if(Util.fireCancellableEvent(shopInventoryPreview)) {
       Log.debug("Inventory preview was canceled by a plugin.");
       return;
     }
-    if(inventory == null) {
-      final int size = 9;
-      inventory = Bukkit.createInventory(new QuickShopPreviewGUIHolder(), size, LegacyComponentSerializer.legacySection().serialize(plugin.text().of(player, "menu.preview").forLocale()));
-      for(int i = 0; i < size; i++) {
-        inventory.setItem(i, itemStack);
+
+    final QuickShop plugin = QuickShop.getInstance();
+
+    Component previewStr = plugin.text().of(player, "quickshop-gui-preview").forLocale();
+    if(PlainTextComponentSerializer.plainText().serialize(previewStr).isEmpty()) {
+      previewStr = Component.text("FIXME: Do not set quickshop-gui-preview to an empty string.", NamedTextColor.RED);
+    }
+
+    final Component finalPreviewStr = previewStr;
+    itemStack.editMeta(meta -> {
+      List<Component> lore = meta.lore();
+      if(lore == null) {
+        lore = new ArrayList<>();
       }
+
+      lore.add(finalPreviewStr);
+      meta.lore(lore);
+
+      meta.getPersistentDataContainer().set(NAMESPACED_KEY, PreviewGuiPersistentDataType.INSTANCE, UUID.randomUUID());
+    });
+
+    final int size = 9;
+    final QuickShopPreviewGUIHolder holder = new QuickShopPreviewGUIHolder();
+    final Inventory inventory = Bukkit.createInventory(holder, size, plugin.text().of(player, "menu.preview").forLocale());
+
+    holder.setInventory(inventory);
+
+    for(int i = 0; i < size; i++) {
+      inventory.setItem(i, itemStack);
     }
     player.openInventory(inventory);
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/holder/QuickShopPreviewGUIHolder.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/holder/QuickShopPreviewGUIHolder.java
@@ -16,7 +16,7 @@ public class QuickShopPreviewGUIHolder implements InventoryHolder {
 
   public void setInventory(final @NotNull Inventory inventory) {
 
-    Preconditions.checkState(this.inventory == null);
+    Preconditions.checkState(this.inventory == null, "cannot update inventory field with another inventory after one has already been set");
     this.inventory = inventory;
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/holder/QuickShopPreviewGUIHolder.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/holder/QuickShopPreviewGUIHolder.java
@@ -1,15 +1,23 @@
 package com.ghostchu.quickshop.util.holder;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
 public class QuickShopPreviewGUIHolder implements InventoryHolder {
+  private Inventory inventory;
 
   @Override
   public @NotNull Inventory getInventory() {
 
-    return null;
+    return this.inventory;
+  }
+
+  public void setInventory(final @NotNull Inventory inventory) {
+
+    Preconditions.checkState(this.inventory == null);
+    this.inventory = inventory;
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

Fixes a bug where the title and item lore of the item preview can be shown using the wrong locale to a player due to caching. I've removed using InventoryPreview instances for each shop and instead made it a static method for opening the inventory for a player, since every player will need their own inventory instance for translations to be correct.

Closing inventories when the shop unloads or has its item changed is removed in favor of closing it when the plugin gets disabled, I doubt preview inventories stay open long enough for that to matter and if they do stay open it also doesn't matter much.

Also fixes QuickShopPreviewGUIHolder#getInventory returning null for a notnull method.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---