### PR TITLE
Use distanceSquared in find subcommand

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
@@ -15,7 +15,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
+import org.bukkit.util.NumberConversions;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -50,8 +50,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
     }
     plugin.getShopManager().findCooldown().put(uuid, System.currentTimeMillis() + plugin.getConfig().getLong("shop.finding.cooldown", 20L) * 1000);
 
-    final Location loc = sender.getLocation().clone();
-    final Vector playerVector = loc.toVector();
+    final Location loc = sender.getLocation();
 
     //Combing command args
     final StringBuilder sb = new StringBuilder(parser.getArgs().getFirst());
@@ -67,7 +66,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
       originLookForSb.append(" ").append(parser.getArgs().get(i));
     }
     final String originLookFor = originLookForSb.toString();
-    final double maxDistance = plugin.getConfig().getInt("shop.finding.distance");
+    final double maxDistanceSquared = NumberConversions.square(plugin.getConfig().getInt("shop.finding.distance"));
     final boolean usingOldLogic = plugin.getConfig().getBoolean("shop.finding.oldLogic");
     final int shopLimit = usingOldLogic? 1 : plugin.getConfig().getInt("shop.finding.limit");
     final boolean allShops = plugin.getConfig().getBoolean("shop.finding.all");
@@ -97,10 +96,10 @@ public class SubCommand_Find implements CommandHandler<Player> {
          && !plugin.perm().hasPermission(sender, "quickshop.other.search")) {
         continue;
       }
-      final Vector shopVector = shop.bukkitLocation().toVector();
-      final double distance = shopVector.distance(playerVector);
+      final Location shopLocation = shop.bukkitLocation();
+      final double distanceSquared = shopLocation.distanceSquared(loc);
       //Check distance
-      if(distance <= maxDistance || global) {
+      if(distanceSquared <= maxDistanceSquared || global) {
         //Collect valid shop that trading items we want
         if(!ChatColor.stripColor(LegacyComponentSerializer.legacySection().serialize(Util.getItemStackName(shop.getItem()))).toLowerCase().contains(lookFor)
            && !shop.getItem().getType().name().toLowerCase().contains(lookFor)
@@ -113,7 +112,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
             continue;
           }
         }
-        aroundShops.put(shop, distance);
+        aroundShops.put(shop, Math.sqrt(distanceSquared));
       }
     }
     //Check if no shops found

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -84,6 +85,9 @@ public class SubCommand_Find implements CommandHandler<Player> {
     } else {
       scanPool = plugin.getShopManager().getLoadedShops();
     }
+
+    final boolean canSearchOther = plugin.perm().hasPermission(sender, "quickshop.other.search");
+
     //Calc distance between player and shop
     for(final Shop shop : scanPool) {
       if(!Objects.equals(shop.bukkitLocation().getWorld(), loc.getWorld())) {
@@ -92,17 +96,16 @@ public class SubCommand_Find implements CommandHandler<Player> {
       if(aroundShops.size() == shopLimit) {
         break;
       }
-      if(!shop.playerAuthorize(sender.getUniqueId(), BuiltInShopPermission.SEARCH)
-         && !plugin.perm().hasPermission(sender, "quickshop.other.search")) {
-        continue;
-      }
       final Location shopLocation = shop.bukkitLocation();
       final double distanceSquared = shopLocation.distanceSquared(loc);
       //Check distance
       if(distanceSquared <= maxDistanceSquared || global) {
+        if(!shop.playerAuthorize(sender.getUniqueId(), BuiltInShopPermission.SEARCH) && !canSearchOther) {
+          continue;
+        }
         //Collect valid shop that trading items we want
-        if(!ChatColor.stripColor(LegacyComponentSerializer.legacySection().serialize(Util.getItemStackName(shop.getItem()))).toLowerCase().contains(lookFor)
-           && !shop.getItem().getType().name().toLowerCase().contains(lookFor)
+        if(!ChatColor.stripColor(LegacyComponentSerializer.legacySection().serialize(Util.getItemStackName(shop.getItem()))).toLowerCase(Locale.ROOT).contains(lookFor)
+           && !shop.getItem().getType().name().toLowerCase(Locale.ROOT).contains(lookFor)
            && !Util.findStringInList(Util.getEnchantsForItemStack(shop.getItem()), lookFor)
            && plugin.getItemMarker().get(originLookFor) == null) {
           continue;

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
@@ -60,7 +60,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
     }
 
 
-    final String lookFor = sb.toString().toLowerCase();
+    final String lookFor = sb.toString().toLowerCase(Locale.ROOT);
 
     final StringBuilder originLookForSb = new StringBuilder(parser.getArgs().getFirst());
     for(int i = 1; i < parser.getArgs().size(); i++) {


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

A very minor improvement in the find subcommand, skips doing a sqrt and playerAuthorize test for shops that are outside of the max distance.

---

## Type of Change

* [ ] Feature
* [ ] Bug fix
* [x] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---