### PR TITLE
Add anti-oxidation configs for copper chests, and PDC to Shop Chests

### DIFF
--- a/.changelog/SNAPSHOTS/6.3.0.0-SNAPSHOT-11.md
+++ b/.changelog/SNAPSHOTS/6.3.0.0-SNAPSHOT-11.md
@@ -7,10 +7,13 @@
   - "TROPICAL_FISH/PATTERN",
   - "TROPICAL_FISH/BASE_COLOR",
   - "TROPICAL_FISH/BASE_COLOR"
+- Added protect.oxidation config.
+  - This allows protecting copper chests from oxidizing
 
 ## Internal Changes
 - Adjusted trade ui to use a stock variable instead of the cache, this should fix issues where stock information was sometimes inaccurate while not sacrificing performance.
 - A very minor improvement in the find subcommand, skips doing a sqrt and playerAuthorize test for shops that are outside of the max distance.(Thanks to Warriorrrr)
+- Started assigning PDC to shop chests which should allow faster checks in the future.
 
 ## Bug Fixes
 - Corrected UI not showing correct items for potions and books

--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/meta/ShopMeta.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/meta/ShopMeta.java
@@ -24,6 +24,7 @@ import com.ghostchu.quickshop.api.obj.QUser;
 import com.ghostchu.quickshop.api.shop.IShopType;
 import com.ghostchu.quickshop.api.shop.state.ShopState;
 import net.kyori.adventure.text.Component;
+import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -92,6 +93,14 @@ public interface ShopMeta<U> extends ShopPrice<U> {
    * @param item ItemStack to set
    */
   void setItem(@NotNull ItemStack item);
+
+  /**
+   * Get shop block
+   *
+   * @return The shop's block
+   */
+  @NotNull
+  Block getShopBlock();
 
   /**
    * Gets the currency that shop use

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/BlockListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/BlockListener.java
@@ -17,12 +17,15 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
@@ -30,6 +33,8 @@ import org.bukkit.event.player.PlayerSignOpenEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static com.ghostchu.quickshop.shop.SimpleShopManager.CHEST_SHOP;
 
 /**
  * BlockListener to listening events about block events
@@ -49,6 +54,34 @@ public class BlockListener extends AbstractProtectionListener {
   private void init() {
 
     this.updateSignWhenInventoryMoving = super.getPlugin().getConfig().getBoolean("shop.update-sign-when-inventory-moving", true);
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onForm(final BlockFormEvent event) {
+
+    if (!getPlugin().getConfig().getBoolean("protect.oxidation")) {
+      return;
+    }
+
+    final Block block = event.getBlock();
+    final BlockState state = block.getState(false);
+
+    //run pdc check first instead of lookup
+    if (state instanceof final TileState tileState && tileState.getPersistentDataContainer().has(CHEST_SHOP)) {
+
+      event.setCancelled(true);
+      return;
+    }
+
+    if (!Util.canBeShop(block, state)) {
+      return;
+    }
+
+    final Shop shop = getShopPlayer(block.getLocation(), false);
+    if (shop == null) {
+      return;
+    }
+    event.setCancelled(true);
   }
 
   /*

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -63,6 +63,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.TileState;
 import org.bukkit.block.sign.Side;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -71,6 +72,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -94,6 +96,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.ghostchu.quickshop.shop.SimpleShopManager.CHEST_SHOP_OWNER;
 import static com.ghostchu.quickshop.util.Util.waitForFuture;
 import static java.math.BigDecimal.ZERO;
 
@@ -531,6 +534,11 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
     setDirty();
   }
 
+  @Override
+  public @NotNull Block getShopBlock() {
+    return this.location.getBlock();
+  }
+
   /**
    * @return The location of the shops chest
    */
@@ -573,6 +581,17 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
       return;
     }
     this.owner = owner;
+
+    //Setup PDC with new owner
+    if (owner.getUniqueId() != null) {
+      final Block block = this.location.getBlock();
+      if(block.getState(false) instanceof final TileState tileState) {
+
+        tileState.getPersistentDataContainer().set(CHEST_SHOP_OWNER, PersistentDataType.STRING, owner.getUniqueId().toString());
+        tileState.update(true);
+      }
+    }
+
     setDirty();
     setSignText(plugin.getTextManager().findRelativeLanguages(owner, false));
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -64,11 +64,13 @@ import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.WallSign;
@@ -79,6 +81,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -108,6 +111,9 @@ import java.util.function.Function;
 public class SimpleShopManager extends AbstractShopManager implements ShopManager, Reloadable {
 
   public static final String DEFAULT_TYPE = "BUYING";
+
+  public static final NamespacedKey CHEST_SHOP = new NamespacedKey(QuickShop.getInstance().getJavaPlugin(), "chest_shop");
+  public static final NamespacedKey CHEST_SHOP_OWNER = new NamespacedKey(QuickShop.getInstance().getJavaPlugin(), "chest_shop_owner");
 
   protected final Map<UUID, Long> cooldowns = Maps.newConcurrentMap();
   protected final Map<Integer, IShopType> shopTypes = Maps.newConcurrentMap();
@@ -877,6 +883,20 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
         addShopToLookupTable(shop);
         registerShop(shop, true);
         loadShop(shop);
+
+        //set PDC on shop block
+        final Block block = shop.getShopBlock();
+        if (block.getState(false) instanceof final TileState tileState) {
+
+          if (shop.getOwner().getUniqueId() != null) {
+
+            tileState.getPersistentDataContainer().set(CHEST_SHOP_OWNER, PersistentDataType.STRING, shop.getOwner().getUniqueId().toString());
+          }
+          tileState.getPersistentDataContainer().set(CHEST_SHOP, PersistentDataType.LONG, shop.getShopId());
+
+          tileState.update(true);
+        }
+
         shop.setSignText(plugin.getTextManager().findRelativeLanguages(p));
 
         event = event.clone(Phase.MAIN);
@@ -1385,6 +1405,25 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
     }
     for(final Sign s : shop.getSigns()) {
       s.getBlock().setType(Material.AIR);
+    }
+
+    final Block shopBlock = shop.getShopBlock();
+    if (shopBlock.getState(false) instanceof final TileState state) {
+
+      boolean updated = false;
+      if (state.getPersistentDataContainer().has(CHEST_SHOP)) {
+        state.getPersistentDataContainer().remove(CHEST_SHOP);
+        updated = true;
+      }
+
+      if (state.getPersistentDataContainer().has(CHEST_SHOP_OWNER)) {
+        state.getPersistentDataContainer().remove(CHEST_SHOP_OWNER);
+        updated = true;
+      }
+
+      if (updated) {
+        state.update(true);
+      }
     }
     refundShop(shop);
     unloadShop(shop);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -473,6 +473,26 @@ public class Util {
     return true;
   }
 
+  public static boolean canBeShop(@NotNull final Block b, final BlockState bs) {
+
+    if(isBlacklistWorld(b.getWorld())) {
+      return false;
+    }
+
+    // Specified types by configuration
+    if(!isShoppables(b.getType())) {
+      return false;
+    }
+
+    if (!(bs instanceof InventoryHolder)) {
+      if(Util.isDevMode()) {
+        Log.debug(b.getType() + " not a container");
+      }
+      return false;
+    }
+    return true;
+  }
+
   public static boolean isBlacklistWorld(@NotNull final World world) {
 
     final List<String> whitelist = plugin.getConfig().getStringList("shop.whitelist-world");

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -11,7 +11,7 @@
 
 # Internal configuration version.
 # Do not change this unless QuickShop support instructs you to.
-config-version: 1045
+config-version: 1046
 
 # Default language used by the plugin.
 # Set to "default" to use the player's Minecraft client language automatically.
@@ -947,6 +947,7 @@ protect:
   dropper: true
   dropper-owner-exclude: false
   entity: true
+  oxidation: true
 
 # Backup Policy
 # Controls when QuickShop creates automatic backups.


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?
- Added protect.oxidation config.
  - This allows protecting copper chests from oxidizing
- Started assigning PDC to shop chests which should allow faster checks in the future.

---

## Type of Change

* [x] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---