### PR TITLE
Keep inventory count cache loaded in memory per shop

### DIFF
--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -8,6 +8,7 @@ import com.ghostchu.quickshop.common.util.QuickExecutor;
 import com.ghostchu.quickshop.economy.QSBenefitProvider;
 import com.ghostchu.quickshop.obj.QUserImpl;
 import com.ghostchu.quickshop.shop.ContainerShop;
+import com.ghostchu.quickshop.shop.cache.SimpleShopInventoryCountCache;
 import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager;
 import com.ghostchu.quickshop.util.ProgressMonitor;
 import com.ghostchu.quickshop.util.performance.BatchBukkitExecutor;
@@ -88,7 +89,8 @@ public class ShopMigrate extends AbstractMigrateComponent {
                 ((BukkitInventoryWrapperManager)getHikari().getInventoryWrapperManager()).mklink(reremakeShop.getLocation()),
                 null,
                 Collections.emptyMap(),
-                new QSBenefitProvider()
+                new QSBenefitProvider(),
+                new SimpleShopInventoryCountCache()
         );
         migrateReremakeBanAddonData(reremakeShop, hikariRawShop);
         hikariRawShop.setDirty();

--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/database/bean/ShopRecord.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/database/bean/ShopRecord.java
@@ -9,4 +9,8 @@ public class ShopRecord {
 
   private DataRecord dataRecord;
   private InfoRecord infoRecord;
+
+  // Extra fields
+  private int cachedStock;
+  private int cachedSpace;
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
@@ -530,7 +530,9 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                        + " INNER JOIN " + DataTables.SHOPS.getName()
                        + " ON " + DataTables.DATA.getName() + ".id = " + DataTables.SHOPS.getName() + ".data"
                        + " INNER JOIN " + DataTables.SHOP_MAP.getName()
-                       + " ON " + DataTables.SHOP_MAP.getName() + ".shop = " + DataTables.SHOPS.getName() + ".id";
+                       + " ON " + DataTables.SHOP_MAP.getName() + ".shop = " + DataTables.SHOPS.getName() + ".id"
+                       + " LEFT JOIN " + DataTables.EXTERNAL_CACHE.getName()
+                       + " ON " + DataTables.EXTERNAL_CACHE.getName() + ".shop = " + DataTables.SHOPS.getName() + ".id";
     try(final SQLQuery query = manager.createQuery().withPreparedSQL(SQL).execute()) {
       final ResultSet rs = query.getResultSet();
       while(rs.next()) {
@@ -544,7 +546,9 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
         final int z = rs.getInt("z");
         final DataRecord dataRecord = new SimpleDataRecord(plugin.getPlayerFinder(), rs);
         final InfoRecord infoRecord = new ShopInfo(shopId, world, x, y, z);
-        shopRecords.add(new ShopRecord(dataRecord, infoRecord));
+        final int cachedStock = rs.getInt("stock");
+        final int cachedSpace = rs.getInt("space");
+        shopRecords.add(new ShopRecord(dataRecord, infoRecord, cachedStock, cachedSpace));
       }
     } catch(final SQLException e) {
       plugin.logger().error("Failed to list shops", e);
@@ -900,7 +904,6 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
   public CompletableFuture<@NotNull ShopInventoryCountCache> queryInventoryCache(final long shopId) {
 
     return CompletableFuture.supplyAsync(()->{
-      ShopInventoryCountCache cache = new SimpleShopInventoryCountCache(-2, -2, false);
       try(final SQLQuery query = DataTables.EXTERNAL_CACHE.createQuery()
               .selectColumns("stock", "space")
               .addCondition("shop", shopId)
@@ -908,12 +911,12 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
               .build().execute()) {
         final ResultSet set = query.getResultSet();
         if(set.next()) {
-          cache = new SimpleShopInventoryCountCache(set.getInt("stock"), set.getInt("space"), true);
+          return new SimpleShopInventoryCountCache(set.getInt("stock"), set.getInt("space"), true);
         }
       } catch(final SQLException exception) {
         plugin.logger().warn("Cannot handle the inventory cache lookup for shop {}", shopId, exception);
       }
-      return cache;
+      return new SimpleShopInventoryCountCache();
     });
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/InternalListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/InternalListener.java
@@ -9,9 +9,10 @@ import com.ghostchu.quickshop.api.event.management.ShopCreateEvent;
 import com.ghostchu.quickshop.api.event.management.ShopDeleteEvent;
 import com.ghostchu.quickshop.api.event.settings.type.ShopPriceEvent;
 import com.ghostchu.quickshop.api.serialize.BlockPos;
-import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.common.util.CommonUtil;
 import com.ghostchu.quickshop.obj.QUserImpl;
+import com.ghostchu.quickshop.shop.ContainerShop;
+import com.ghostchu.quickshop.shop.cache.SimpleShopInventoryCountCache;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logger.Log;
 import com.ghostchu.quickshop.util.logging.container.PlayerEconomyPreCheckLog;
@@ -21,8 +22,6 @@ import com.ghostchu.quickshop.util.logging.container.ShopPurchaseLog;
 import com.ghostchu.quickshop.util.logging.container.ShopRemoveLog;
 import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.ReloadStatus;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
@@ -30,18 +29,11 @@ import org.bukkit.event.EventPriority;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 
 public class InternalListener extends AbstractQSListener {
 
   private final QuickShop plugin;
-  private final Cache<Shop, SpaceCache> countUpdateCache = CacheBuilder
-          .newBuilder()
-          .weakKeys()
-          .expireAfterAccess(5, TimeUnit.MINUTES)
-          .maximumSize(100)
-          .build();
   private boolean loggingBalance;
   private boolean loggingAction;
 
@@ -113,14 +105,15 @@ public class InternalListener extends AbstractQSListener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void shopInventoryCalc(final ShopInventoryCalculateEvent event) {
 
-    if(event.getShop().getShopId() < 1) {
+    if(event.getShop().getShopId() < 0) {
       return;
     }
-    final SpaceCache count = countUpdateCache.getIfPresent(event.getShop());
-    if(count != null && count.getSpace() == event.getSpace() && count.getStock() == event.getStock()) {
+    final SimpleShopInventoryCountCache count = ((ContainerShop) event.getShop()).getInventoryCountCache();
+    if(count.getSpace() == event.getSpace() && count.getStock() == event.getStock()) {
       return;
     }
-    countUpdateCache.put(event.getShop(), new SpaceCache(event.getSpace(), event.getStock()));
+    count.setSpace(event.getSpace());
+    count.setStock(event.getStock());
     plugin.getDatabaseHelper().updateExternalInventoryProfileCache(event.getShop().getShopId(), event.getSpace(), event.getStock())
             .exceptionally(err->{
               Log.debug("Error updating external inventory profile cache for shop " + event.getShop().getShopId() + ": " + err.getMessage());
@@ -172,28 +165,6 @@ public class InternalListener extends AbstractQSListener {
     }
     if(event.getPurchaser().equals(event.getShop().getOwner())) {
       plugin.text().of(event.getPurchaser(), "shop-owner-self-trade").send();
-    }
-  }
-
-  static class SpaceCache {
-
-    private final int stock;
-    private final int space;
-
-    public SpaceCache(final int stock, final int space) {
-
-      this.stock = stock;
-      this.space = space;
-    }
-
-    public int getSpace() {
-
-      return space;
-    }
-
-    public int getStock() {
-
-      return stock;
     }
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/browse/MarketUtils.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/browse/MarketUtils.java
@@ -20,8 +20,8 @@ package com.ghostchu.quickshop.menu.browse;
 import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.shop.ItemMatcher;
 import com.ghostchu.quickshop.api.shop.Shop;
-import com.ghostchu.quickshop.api.shop.cache.ShopInventoryCountCache;
 import com.ghostchu.quickshop.common.util.CommonUtil;
+import com.ghostchu.quickshop.shop.ContainerShop;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -411,16 +411,8 @@ public final class MarketUtils {
     if(shop.isUnlimited()) {
       return -1;
     }
-    try {
-      final ShopInventoryCountCache cache = QuickShop.getInstance().getShopManager()
-              .queryShopInventoryCacheInDatabase(shop).join();
-      final int stock = cache.getStock();
-      // Return stock if available, otherwise return 0 for uninitialized cache
-      return stock >= 0? stock : 0;
-    } catch(final Exception e) {
-      // Fallback to 0 if cache query fails
-      return 0;
-    }
+
+    return Math.max(((ContainerShop) shop).getInventoryCountCache().getStock(), 0);
   }
 
   /**
@@ -436,15 +428,7 @@ public final class MarketUtils {
     if(shop.isUnlimited()) {
       return -1;
     }
-    try {
-      final ShopInventoryCountCache cache = QuickShop.getInstance().getShopManager()
-              .queryShopInventoryCacheInDatabase(shop).join();
-      final int space = cache.getSpace();
-      // Return space if available, otherwise return 0 for uninitialized cache
-      return space >= 0? space : 0;
-    } catch(final Exception e) {
-      // Fallback to 0 if cache query fails
-      return 0;
-    }
+
+    return Math.max(((ContainerShop) shop).getInventoryCountCache().getSpace(), 0);
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -828,7 +828,7 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
       final InventoryWrapper inv = this.getInventory();
       if(inv == null) {
         Log.debug("Failed to calc RemainingSpace for shop " + this + ": Inventory null.");
-        return Math.max(inventoryCountCache.getSpace(), 0);
+        return 0;
       }
 
       final int space = Util.countSpace(inv, this);
@@ -886,8 +886,7 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
 
     final InventoryWrapper inventoryWrapper = getInventory();
     if(inventoryWrapper == null) {
-      Log.debug("Failed to calc RemainingStock for shop " + this + ": Inventory null.");
-      return Math.max(inventoryCountCache.getStock(), 0);
+      return 0;
     }
 
     final int stock = Util.countItems(inventoryWrapper, this);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -41,6 +41,7 @@ import com.ghostchu.quickshop.common.util.CommonUtil;
 import com.ghostchu.quickshop.common.util.JsonUtil;
 import com.ghostchu.quickshop.database.bean.SimpleDataRecord;
 import com.ghostchu.quickshop.obj.QUserImpl;
+import com.ghostchu.quickshop.shop.cache.SimpleShopInventoryCountCache;
 import com.ghostchu.quickshop.shop.datatype.ShopSignPersistentDataType;
 import com.ghostchu.quickshop.shop.display.AbstractDisplayItem;
 import com.ghostchu.quickshop.shop.display.display.DisplayEntityItemManager;
@@ -74,6 +75,7 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -155,6 +157,10 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
   @NotNull
   private BenefitProvider benefit;
 
+  @NotNull
+  @EqualsAndHashCode.Exclude
+  private final SimpleShopInventoryCountCache inventoryCountCache;
+
   //updating objects
   private final AtomicBoolean updatingAtomic = new AtomicBoolean(false);
   private volatile CompletableFuture<Void> inFlightUpdate;
@@ -191,7 +197,8 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
           @NotNull final String symbolLink,
           @Nullable final String shopName,
           @NotNull final Map<UUID, String> playerGroup,
-          @NotNull final BenefitProvider shopBenefit) {
+          @NotNull final BenefitProvider shopBenefit,
+          @NotNull final SimpleShopInventoryCountCache inventoryCountCache) {
 
     this.shopId = shopId;
     this.shopName = shopName;
@@ -240,6 +247,7 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
     }
     this.symbolLink = symbolLink;
     this.inventoryWrapperProvider = inventoryWrapperProvider;
+    this.inventoryCountCache = inventoryCountCache;
     updateShopData();
     // ContainerShop constructor is not allowed to write any persistent data to disk
     // ContainerShop constructor may run on both ServerThread and AsyncThread
@@ -815,20 +823,21 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
       return -1;
     }
 
-    if(Bukkit.isPrimaryThread()) {
+    if(plugin.getJavaPlugin().getServer().isOwnedByCurrentRegion(location) ) {
 
-      if(this.getInventory() == null) {
+      final InventoryWrapper inv = this.getInventory();
+      if(inv == null) {
         Log.debug("Failed to calc RemainingSpace for shop " + this + ": Inventory null.");
-        return 0;
+        return Math.max(inventoryCountCache.getSpace(), 0);
       }
 
-      final int space = Util.countSpace(this.getInventory(), this);
+      final int space = Util.countSpace(inv, this);
       new ShopInventoryCalculateEvent(this, space, -1).callEvent();
       Log.debug("Space count is: " + space);
       return space;
     } else {
 
-      return plugin.getShopManager().queryShopInventoryCacheInDatabase(this).join().getSpace();
+      return Math.max(inventoryCountCache.getSpace(), 0);
     }
   }
 
@@ -877,7 +886,8 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
 
     final InventoryWrapper inventoryWrapper = getInventory();
     if(inventoryWrapper == null) {
-      return 0;
+      Log.debug("Failed to calc RemainingStock for shop " + this + ": Inventory null.");
+      return Math.max(inventoryCountCache.getStock(), 0);
     }
 
     final int stock = Util.countItems(inventoryWrapper, this);
@@ -2083,6 +2093,12 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
       return Objects.requireNonNull(this.item.getItemMeta()).getEnchants();
     }
     return Collections.emptyMap();
+  }
+
+  @ApiStatus.Internal
+  public @NotNull SimpleShopInventoryCountCache getInventoryCountCache() {
+
+    return inventoryCountCache;
   }
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
@@ -13,6 +13,7 @@ import com.ghostchu.quickshop.common.util.CommonUtil;
 import com.ghostchu.quickshop.common.util.JsonUtil;
 import com.ghostchu.quickshop.common.util.Timer;
 import com.ghostchu.quickshop.economy.QSBenefitProvider;
+import com.ghostchu.quickshop.shop.cache.SimpleShopInventoryCountCache;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logger.Log;
 import com.ghostchu.quickshop.util.paste.item.SubPasteItem;
@@ -121,7 +122,7 @@ public class ShopLoader implements SubPasteItem {
       final InfoRecord infoRecord = shopRecord.getInfoRecord();
       final DataRecord dataRecord = shopRecord.getDataRecord();
       final Timer singleShopLoadingTimer = new Timer(true);
-      final ShopLoadResult result = loadSingleShop(infoRecord, dataRecord, worldName, shopsLoadInNextTick);
+      final ShopLoadResult result = loadSingleShop(shopRecord, worldName, shopsLoadInNextTick);
       switch(result) {
         case LOADED -> successCounter.incrementAndGet();
         case LOAD_AFTER_CHUNK_LOADED -> chunkNotLoaded.incrementAndGet();
@@ -141,7 +142,10 @@ public class ShopLoader implements SubPasteItem {
   }
 
 
-  private ShopLoadResult loadSingleShop(final InfoRecord infoRecord, final DataRecord dataRecord, @Nullable final String worldName, @NotNull final List<Shop> shopsLoadInNextTick) {
+  private ShopLoadResult loadSingleShop(final ShopRecord shopRecord, @Nullable final String worldName, @NotNull final List<Shop> shopsLoadInNextTick) {
+    final InfoRecord infoRecord = shopRecord.getInfoRecord();
+    final DataRecord dataRecord = shopRecord.getDataRecord();
+
     // World check
     if(worldName != null) {
       if(!worldName.equals(infoRecord.getWorld())) {
@@ -172,6 +176,10 @@ public class ShopLoader implements SubPasteItem {
     final DataRawDatabaseInfo rawInfo = new DataRawDatabaseInfo(dataRecord);
     final Location location = new Location(Bukkit.getWorld(infoRecord.getWorld()), x, y, z);
 
+    final SimpleShopInventoryCountCache countCache = shopRecord.getCachedSpace() == 0 && shopRecord.getCachedStock() == 0
+            ? new SimpleShopInventoryCountCache() // cached stock & space both being 0 means no external cache existed, create uninitialized cache
+            : new SimpleShopInventoryCountCache(shopRecord.getCachedStock(), shopRecord.getCachedSpace(), true);
+
     final ItemStack stack = (rawInfo.getNewItem() == null)? rawInfo.getItem() : rawInfo.getNewItem();
     try {
       shop = new ContainerShop(plugin,
@@ -191,7 +199,9 @@ public class ShopLoader implements SubPasteItem {
                                rawInfo.getInvSymbolLink(),
                                rawInfo.getName(),
                                rawInfo.getPermissions(),
-                               rawInfo.getBenefits());
+                               rawInfo.getBenefits(),
+                               countCache
+      );
     } catch(final Exception e) {
       if(e instanceof IllegalStateException) {
         plugin.logger().warn("Failed to load the shop, skipping...", e);
@@ -319,6 +329,7 @@ public class ShopLoader implements SubPasteItem {
     private boolean needUpdate = false;
 
     private BenefitProvider benefits;
+    private SimpleShopInventoryCountCache inventoryCountCache;
 
 
     DataRawDatabaseInfo(@NotNull final DataRecord dataRecord) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -42,6 +42,7 @@ import com.ghostchu.quickshop.economy.QSBenefitProvider;
 import com.ghostchu.quickshop.economy.transaction.QSEconomyTransaction;
 import com.ghostchu.quickshop.economy.transaction.QSEconomyTransactionBuilder;
 import com.ghostchu.quickshop.obj.QUserImpl;
+import com.ghostchu.quickshop.shop.cache.SimpleShopInventoryCountCache;
 import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapper;
 import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager;
 import com.ghostchu.quickshop.shop.tax.QuickShopTaxManager;
@@ -561,7 +562,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
                                                      SELLING_TYPE, ACTIVE_STATE, new YamlConfiguration(), null, !plugin.getConfig().getBoolean("shop.display-default", true),
                                                      null, plugin.getJavaPlugin().getName(),
                                                      symbolLink,
-                                                     null, Collections.emptyMap(), new QSBenefitProvider());
+                                                     null, Collections.emptyMap(), new QSBenefitProvider(), new SimpleShopInventoryCountCache());
         createShop(shop, info.getSignBlock(), info.isBypassed());
       } else {
         plugin.text().of(p, "invalid-container").send();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/cache/SimpleShopInventoryCountCache.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/cache/SimpleShopInventoryCountCache.java
@@ -8,6 +8,11 @@ public class SimpleShopInventoryCountCache implements ShopInventoryCountCache {
   private int space;
   private boolean initialized = false;
 
+  public SimpleShopInventoryCountCache() {
+
+    this(-2, -2, false);
+  }
+
   public SimpleShopInventoryCountCache(final int stock, final int space, final boolean initialized) {
 
     this.stock = stock;


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
Loads data from the external_cache table into memory at startup and keeps it there, this allows the inventory cache to be retrieved instantly instead of waiting for a database call, drastically speeding up parts of the plugin that rely on this.

The in-memory cache is updated at the same time as the database being updated, so it should be just as accurate as the existing implementation was.

If there's any better way of passing the cached stock/space through to the shop loader then let me know and I can update that.

---

## Type of Change

* [x] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---