### PR TITLE
Read stock amount from the cache for map addons

### DIFF
--- a/addon/bluemap/src/main/java/com/ghostchu/quickshop/addon/bluemap/Main.java
+++ b/addon/bluemap/src/main/java/com/ghostchu/quickshop/addon/bluemap/Main.java
@@ -3,6 +3,7 @@ package com.ghostchu.quickshop.addon.bluemap;
 import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.localization.text.TextManager;
 import com.ghostchu.quickshop.api.shop.Shop;
+import com.ghostchu.quickshop.menu.browse.MarketUtils;
 import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.BlueMapWorld;
@@ -157,7 +158,8 @@ public final class Main extends JavaPlugin implements Listener {
     s = s.replace("%owner%", plain(shop.ownerName()));
     s = s.replace("%item%", shop.getItem().getType().name());
     s = s.replace("%price%", String.valueOf(shop.getPrice()));
-    s = s.replace("%stock%", String.valueOf(shop.getRemainingStock()));
+    final int stock = shop.shopType().isBuying() ? MarketUtils.getSpaceFromCache(shop) : MarketUtils.getStockFromCache(shop);
+    s = s.replace("%stock%", String.valueOf(stock == -1 ? "Unlimited" : stock));
     s = s.replace("%type%", shop.shopType().identifier());
     s = s.replace("%location%", x + "," + y + "," + z);
     return s;

--- a/addon/pl3xmap/src/main/java/com/ghostchu/quickshop/addon/pl3xmap/ShopMarkerManager.java
+++ b/addon/pl3xmap/src/main/java/com/ghostchu/quickshop/addon/pl3xmap/ShopMarkerManager.java
@@ -1,6 +1,7 @@
 package com.ghostchu.quickshop.addon.pl3xmap;
 
 import com.ghostchu.quickshop.api.shop.Shop;
+import com.ghostchu.quickshop.menu.browse.MarketUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.pl3x.map.core.markers.Point;
@@ -96,7 +97,8 @@ public class ShopMarkerManager {
     s = s.replace("%owner%", plain(shop.ownerName()));
     s = s.replace("%item%", shop.getItem().getType().name());
     s = s.replace("%price%", String.valueOf(shop.getPrice()));
-    s = s.replace("%stock%", String.valueOf(shop.getRemainingStock()));
+    final int stock = shop.shopType().isBuying() ? MarketUtils.getSpaceFromCache(shop) : MarketUtils.getStockFromCache(shop);
+    s = s.replace("%stock%", String.valueOf(stock == -1 ? "Unlimited" : stock));
     s = s.replace("%type%", shop.shopType().identifier());
     s = s.replace("%location%", x + "," + y + "," + z);
     return s;

--- a/addon/squaremap/src/main/java/com/ghostchu/quickshop/addon/squaremap/ShopLayerProvider.java
+++ b/addon/squaremap/src/main/java/com/ghostchu/quickshop/addon/squaremap/ShopLayerProvider.java
@@ -2,6 +2,7 @@ package com.ghostchu.quickshop.addon.squaremap;
 
 import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.shop.Shop;
+import com.ghostchu.quickshop.menu.browse.MarketUtils;
 import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -122,10 +123,12 @@ public class ShopLayerProvider {
     final String y = String.valueOf(loc.getBlockY());
     final String z = String.valueOf(loc.getBlockZ());
 
+    final int stock = shop.shopType().isBuying() ? MarketUtils.getSpaceFromCache(shop) : MarketUtils.getStockFromCache(shop);
+
     return text.replace("%owner%", plain(shop.ownerName()))
         .replace("%item%", shop.getItem().getType().name())
         .replace("%price%", String.valueOf(shop.getPrice()))
-        .replace("%stock%", String.valueOf(shop.getRemainingStock()))
+        .replace("%stock%", String.valueOf(stock == -1 ? "Unlimited" : stock))
         .replace("%type%", shop.shopType().identifier())
         .replace("%location%", x + "," + y + "," + z)
         .replace("%x%", x)


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

Uses the inventory count cache for updating placeholders in the various map addons, instead of attempting to schedule onto the region to get it. Dynmap doesn't seem to display the remaining stock on the map so I have not updated anything there.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [ ] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

Fixes #2443

---