### PR TITLE
Add a cooldown to the shop info panel to prevent malicious server lag.

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -47,6 +47,7 @@ import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapper;
 import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager;
 import com.ghostchu.quickshop.shop.tax.QuickShopTaxManager;
 import com.ghostchu.quickshop.util.ChatSheetPrinter;
+import com.ghostchu.quickshop.util.ExpiringSet;
 import com.ghostchu.quickshop.util.MsgUtil;
 import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
@@ -120,6 +121,19 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
   protected final Map<Integer, IShopType> shopTypes = Maps.newConcurrentMap();
   protected final Map<String, ShopState> shopStates = Maps.newConcurrentMap();
   protected final ConcurrentLinkedQueue<Long> inDeletion = new ConcurrentLinkedQueue<>();
+
+  /**
+   * Per-(player, shop) sliding-window rate-limit for the shop info panel send. A key of
+   * {@code playerUuid|world:x,y,z} still present in the set means the player clicked this
+   * same shop within {@code shop.info-panel.click-cooldown} ms, so {@link #sendShopInfo}
+   * returns early—no header/owner/item/stock lines are rebuilt and re-sent, while trading
+   * and the how-many prompt (which live in {@code ShopUtil} after this call) keep working.
+   *
+   * <p>The cooldown is refreshed on every click (sliding window): a player spam-clicking
+   * the same shop sees the info panel exactly once and never again until they stop clicking
+   * for longer than the configured cooldown.</p>
+   */
+  private ExpiringSet<String> infoRateLimit;
 
   protected final InteractiveManager interactiveManager;
   protected final TaxManager taxManager;
@@ -218,6 +232,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
     this.sendStockMessageToStaff = plugin.getConfig().getBoolean("shop.sending-stock-message-to-staffs");
     this.useShopableChecks = plugin.getConfig().getBoolean("shop.shoppable-check", false);
     this.useShopCache = plugin.getConfig().getBoolean("shop.use-cache", true);
+    this.infoRateLimit = new ExpiringSet<>(Math.max(0L, plugin.getConfig().getLong("shop.info-panel.click-cooldown", 1000L)), TimeUnit.MILLISECONDS);
 
   }
 
@@ -1075,6 +1090,17 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       }
       if(Util.fireCancellableEvent(new ShopInfoPanelEvent(shop, p.getUniqueId()))) {
         Log.debug("ShopInfoPanelEvent cancelled by some plugin");
+        return;
+      }
+      final Location shopLoc = shop.bukkitLocation();
+      final String infoKey = p.getUniqueId() + "|" + shopLoc.getWorld().getName() + ":" + shopLoc.getBlockX() + "," + shopLoc.getBlockY() + "," + shopLoc.getBlockZ();
+      final boolean throttled = infoRateLimit.contains(infoKey);
+      // Always (re)add so every click slides the expiry forward: a player spam-clicking the
+      // same shop is throttled indefinitely and sees the info panel exactly once until they
+      // stop clicking for longer than the configured cooldown.
+      infoRateLimit.add(infoKey);
+      if(throttled) {
+        Log.debug("Shop info panel skipped: same shop clicked too fast by " + p.getName());
         return;
       }
       final ProxiedLocale locale = plugin.text().findRelativeLanguages(p);

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -782,6 +782,11 @@ shop:
     show-effects: true
     show-enchantments: true
     show-durability: true
+    # Minimum interval (in milliseconds) between repeated shop info-panel sends to the same
+    # player for the SAME shop. Spam-clicking one shop skips re-sending the info panel,
+    # while trading and the "how many to buy/sell" prompt still work normally.
+    # Set to 0 to disable.
+    click-cooldown: 1000
 
 # Item Blacklist
 # Items that cannot be sold in shops.

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -786,7 +786,7 @@ shop:
     # player for the SAME shop. Spam-clicking one shop skips re-sending the info panel,
     # while trading and the "how many to buy/sell" prompt still work normally.
     # Set to 0 to disable.
-    click-cooldown: 1000
+    click-cooldown: 100
 
 # Item Blacklist
 # Items that cannot be sold in shops.


### PR DESCRIPTION
# Summary

What does this PR do?

Adds a cooldown to displaying the shop info panel to prevent some users from maliciously causing server lag.

# Type of Change

* [✓] Feature
* [✓] Configuration/File

# Basic Checklist

* [✓] I have tested these changes locally.
* [✓] This PR used AI-assisted code generation, and the generated code has been reviewed and audited.

# Notes (Optional)

Additional information for reviewers:

* **Why this change is needed:** Some players can use multiple alternate accounts together with AFK/macros to repeatedly open the shop info panel, resulting in excessive server resource usage.
* **Edge cases:** Rapid repeated clicking on chest/shop interfaces.
* **Implementation details:** Introduces a click cooldown to mitigate macro-based spam.

# Configuration Changes (If Applicable)

Only fill out this section if configuration has been modified:

* **Added/Changed:** `shop.info-panel.click-cooldown`
* **Default value:** `100`
* **Risks or considerations:** None. Suitable for approximately 99.99% of servers.

# Relevant documents
<img width="903" height="776" alt="3b78a3bbbf53a09d83c78d906ce09e10" src="https://github.com/user-attachments/assets/f198181b-da7a-449a-b9c1-7f2e22ba1b51" />

Modified video display

https://github.com/user-attachments/assets/85ad4d91-c534-4273-af50-301756d2907e

