### PR TITLE
Add missing integer validation

### DIFF
--- a/addon/list/src/main/java/com/ghostchu/quickshop/addon/list/command/SubCommand_List.java
+++ b/addon/list/src/main/java/com/ghostchu/quickshop/addon/list/command/SubCommand_List.java
@@ -36,9 +36,9 @@ public class SubCommand_List implements CommandHandler<Player> {
       lookupSelf(sender, page);
       return;
     }
-    if(!CommonUtil.isNumeric(parser.getArgs().getFirst())) {
+    if(!CommonUtil.isInteger(parser.getArgs().getFirst())) {
       if(parser.getArgs().size() >= 2) {
-        if(!CommonUtil.isNumeric(parser.getArgs().get(1))) {
+        if(!CommonUtil.isInteger(parser.getArgs().get(1))) {
           quickshop.text().of(sender, "not-a-number", parser.getArgs().get(1)).send();
           return;
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Refill.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Refill.java
@@ -33,7 +33,7 @@ public class SubCommand_Refill implements CommandHandler<Player> {
       plugin.text().of(sender, "not-looking-at-shop").send();
       return;
     }
-    if(CommonUtil.isNumeric(parser.getArgs().getFirst())) {
+    if(CommonUtil.isInteger(parser.getArgs().getFirst())) {
       add = Integer.parseInt(parser.getArgs().getFirst());
     } else {
       if(parser.getArgs().getFirst().equals(plugin.getConfig().getString("shop.word-for-trade-all-items"))) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/papi/impl/PurchasesPAPI.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/papi/impl/PurchasesPAPI.java
@@ -61,7 +61,7 @@ public class PurchasesPAPI implements PAPISubHandler {
     }
     final String type = passThroughArgs[0];
     final String days = passThroughArgs[1];
-    if(!CommonUtil.isNumeric(days)) {
+    if(!CommonUtil.isInteger(days)) {
       return null;
     }
     final IShopType shopType = QuickShop.getInstance().getShopManager().shopTypeOrDefault(type.toUpperCase(Locale.ROOT));
@@ -91,7 +91,7 @@ public class PurchasesPAPI implements PAPISubHandler {
     }
     final String type = passThroughArgs[0];
     final String days = passThroughArgs[1];
-    if(!CommonUtil.isNumeric(days)) {
+    if(!CommonUtil.isInteger(days)) {
       return null;
     }
     final IShopType shopType = QuickShop.getInstance().getShopManager().shopTypeOrDefault(type.toUpperCase(Locale.ROOT));

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/papi/impl/TransactionAmountPAPI.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/papi/impl/TransactionAmountPAPI.java
@@ -62,7 +62,7 @@ public class TransactionAmountPAPI implements PAPISubHandler {
     }
     final String type = passThroughArgs[0];
     final String days = passThroughArgs[1];
-    if(!CommonUtil.isNumeric(days)) {
+    if(!CommonUtil.isInteger(days)) {
       return null;
     }
     final IShopType shopType = QuickShop.getInstance().getShopManager().shopTypeOrDefault(type.toUpperCase(Locale.ROOT));
@@ -93,7 +93,7 @@ public class TransactionAmountPAPI implements PAPISubHandler {
     }
     final String type = passThroughArgs[0];
     final String days = passThroughArgs[1];
-    if(!CommonUtil.isNumeric(days)) {
+    if(!CommonUtil.isInteger(days)) {
       return null;
     }
     final IShopType shopType = QuickShop.getInstance().getShopManager().shopTypeOrDefault(type.toUpperCase(Locale.ROOT));

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/registry/builtin/itemexpression/handlers/SimpleEnchantmentExpressionHandler.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/registry/builtin/itemexpression/handlers/SimpleEnchantmentExpressionHandler.java
@@ -48,14 +48,14 @@ public class SimpleEnchantmentExpressionHandler implements ItemExpressionHandler
     int minLevel = -1;
     final int maxLevel;
     if(split.length > 1) {
-      if(CommonUtil.isNumeric(split[1])) {
+      if(CommonUtil.isInteger(split[1])) {
         minLevel = Integer.parseInt(split[1]);
       } else {
         return false;
       }
     }
     if(split.length > 2) {
-      if(CommonUtil.isNumeric(split[2])) {
+      if(CommonUtil.isInteger(split[2])) {
         maxLevel = Integer.parseInt(split[2]);
       } else {
         return false;

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -1449,7 +1449,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       return;
     }
     if(shop.isBuying()) {
-      if(CommonUtil.isNumeric(message)) {
+      if(CommonUtil.isInteger(message)) {
         amount = Integer.parseInt(message);
       } else {
         if(message.equalsIgnoreCase(tradeAllKeyword)) {
@@ -1464,7 +1464,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       }
       actionBuying(p, new BukkitInventoryWrapper(p.getInventory()), eco, info, shop, amount);
     } else if(shop.isSelling()) {
-      if(CommonUtil.isNumeric(message)) {
+      if(CommonUtil.isInteger(message)) {
         amount = Integer.parseInt(message);
       } else {
         if(message.equalsIgnoreCase(tradeAllKeyword)) {

--- a/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/CommonUtil.java
+++ b/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/CommonUtil.java
@@ -141,23 +141,43 @@ public class CommonUtil {
     return str1.equals(str2);
   }
 
+  /**
+   * {@return whether the provided sequence consts of only digits}
+   * @param sequence The sequence to check
+   */
   public static boolean isNumeric(final CharSequence sequence) {
 
     if(sequence == null || sequence.isEmpty()) {
       return false;
     }
 
-    boolean numeric = true;
     for(int i = 0; i < sequence.length(); i++) {
 
       if(Character.isDigit(sequence.charAt(i))) {
         continue;
       }
 
-      numeric = false;
-      break;
+      return false;
     }
-    return numeric;
+    return true;
+  }
+
+  /**
+   * {@return whether the provided sequence is a valid integer}
+   * @param sequence The sequence to check
+   */
+  public static boolean isInteger(final CharSequence sequence) {
+
+    if(!isNumeric(sequence)) {
+      return false;
+    }
+
+    try {
+      Integer.parseInt(sequence.toString());
+      return true;
+    } catch(NumberFormatException e) {
+      return false;
+    }
   }
 
   public static String subAfter(final String string, final @NotNull String separator) {

--- a/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/CommonUtil.java
+++ b/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/CommonUtil.java
@@ -163,11 +163,12 @@ public class CommonUtil {
   }
 
   /**
-   * {@return whether the provided sequence is a valid integer}
+   * {@return whether the provided sequence is a valid non-negative integer}
    * @param sequence The sequence to check
    */
   public static boolean isInteger(final CharSequence sequence) {
 
+    // isNumeric currently returns false for the '-' character, which ensures that this only returns true for non-negative ints.
     if(!isNumeric(sequence)) {
       return false;
     }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

isNumeric only checked whether the string only contained digits, and not whether the string is a valid integer. This PR adds a new method that does check if the string is a valid integer, and moves all places that were using isNumeric for integers over to it (which was all of them).

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---