### PR TITLE
Fix NPE when using InventoryWrapper#changeItem

### DIFF
--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/inventory/InventoryWrapper.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/inventory/InventoryWrapper.java
@@ -36,11 +36,17 @@ public interface InventoryWrapper extends Iterable<ItemStack> {
     boolean shouldContinue = true;
     while(shouldContinue && iterator.hasNext()) {
       final ItemStack itemStack = iterator.next();
+      if(itemStack == null) {
+        continue;
+      }
+
+      final ItemStack original = itemStack.clone();
       shouldContinue = itemChanger.changeItem(index, itemStack);
       if(itemStack.getAmount() == 0 || itemStack.getType() == Material.AIR) {
         iterator.setCurrent(null);
 
-      } else {
+      } else if(!original.equals(itemStack)) {
+        // only update when changed
         iterator.setCurrent(itemStack);
       }
       index++;

--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/inventory/InventoryWrapperIterator.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/inventory/InventoryWrapperIterator.java
@@ -33,7 +33,7 @@ public interface InventoryWrapperIterator extends Iterator<ItemStack> {
       }
 
       @Override
-      public ItemStack next() {
+      public @Nullable ItemStack next() {
 
         if(!hasNext()) {
           throw new NoSuchElementException();
@@ -70,7 +70,7 @@ public interface InventoryWrapperIterator extends Iterator<ItemStack> {
       }
 
       @Override
-      public ItemStack next() {
+      public @Nullable ItemStack next() {
 
         if(!hasNext()) {
           throw new NoSuchElementException();
@@ -95,6 +95,7 @@ public interface InventoryWrapperIterator extends Iterator<ItemStack> {
    * @return the next ItemStack instance
    */
   @Override
+  @Nullable
   ItemStack next();
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
Fixes an NPE when using InventoryWrapper#changeItem with an inventory that contains null/air items, and clones the item prior to modification to avoid updating the whole inventory via setCurrent if no modification happened

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [ ] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---