### PR TITLE
Remove duplicate setSignText scheduling on shop click

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/interaction/behaviors/ControlPanel.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/interaction/behaviors/ControlPanel.java
@@ -101,6 +101,5 @@ public class ControlPanel implements InteractionBehavior {
     MsgUtil.sendControlPanelInfo(player, shop);
     Util.playClickSound(player);
     shop.onClick(player);
-    shop.setSignText(((QuickShop)plugin).text().findRelativeLanguages(player));
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -304,7 +304,6 @@ public class ShopUtil {
       return false;
     }
     QuickShop.getInstance().getShopManager().sendShopInfo(p, shop);
-    shop.setSignText(QuickShop.getInstance().text().findRelativeLanguages(p));
     Util.playClickSound(p);
     shop.onClick(p);
     if(shop.getRemainingSpace() == 0) {
@@ -381,13 +380,12 @@ public class ShopUtil {
       return false;
     }
     QuickShop.getInstance().getShopManager().sendShopInfo(p, shop);
-    shop.setSignText(QuickShop.getInstance().text().findRelativeLanguages(p));
+    Util.playClickSound(p);
+    shop.onClick(p);
     if(shop.getRemainingStock() == 0) {
       QuickShop.getInstance().text().of(p, "purchase-out-of-stock", shop.ownerName()).send();
       return true;
     }
-    Util.playClickSound(p);
-    shop.onClick(p);
     final EconomyProvider eco = QuickShop.getInstance().getEconomyManager().provider();
     final double price = shop.getPrice();
     final Inventory playerInventory = p.getInventory();


### PR DESCRIPTION
## Summary

Removes duplicate sign-text refresh calls on shop click. `onClick()` already refreshes the sign internally — the callers were calling it again separately right after, doing the same work twice for no reason.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Config Changes

None.

---

## Breaking Changes

None.

---

## Related

* None