### PR TITLE
ci: disable Gradle config cache, dedupe Gradle caching

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           java-version: "21"
           distribution: temurin
-          cache: gradle
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,14 +29,6 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Cache Gradle configuration cache
-        uses: actions/cache@v4
-        with:
-          path: .gradle/configuration-cache
-          key: gradle-config-cache-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: |
-            gradle-config-cache-${{ runner.os }}-
-
       - name: Build with Gradle
         run: ./gradlew build -x :compatibility:itemsadder:compileJava -x :compatibility:itemsadder:shadowJar -x :compatibility:itemsadder:jar
 

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           java-version: "21"
           distribution: temurin
-          cache: gradle
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/publish-hangar.yml
+++ b/.github/workflows/publish-hangar.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           java-version: "21"
           distribution: temurin
-          cache: gradle
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/publish-modrinth.yml
+++ b/.github/workflows/publish-modrinth.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           java-version: "21"
           distribution: temurin
-          cache: gradle
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/snapshot-gh-release.yml
+++ b/.github/workflows/snapshot-gh-release.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           java-version: "21"
           distribution: temurin
-          cache: gradle
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g
-org.gradle.configuration-cache=true


### PR DESCRIPTION
Turned off org.gradle.configuration-cache. Also removed cache: gradle from setup-java in all workflows since it duplicates setup-gradle's own caching and can get stuck on a broken cache key.