### PR TITLE
Fix reremake migrator issue

### DIFF
--- a/addon/reremake-migrator/build.gradle.kts
+++ b/addon/reremake-migrator/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     compileOnly(project(":quickshop-bukkit"))
     compileOnly("io.vavr:vavr:0.10.7")
     compileOnly("org.maxgamer:QuickShop:5.1.2.5-SNAPSHOT") { isTransitive = false }
-    implementation("de.themoep:minedown-adventure:1.7.4-SNAPSHOT")
+    implementation("de.themoep:minedown-adventure:1.7.6-SNAPSHOT")
     implementation("com.ghostchu.thirdparty:JsonConfiguration:1.2-20230922.165143-1")
     implementation("net.minidev:json-smart:1.1.1")
 }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

fix reremake migrator can't migrate language issue

```
[13:42:26] [Craft Scheduler Thread - 9 - QuickShop-Hikari/WARN]: [QuickShop-Hikari] Plugin QuickShop-Hikari v6.3.0.0 generated an exception while executing task 416
java.lang.IncompatibleClassChangeError: Failed same module check: subclass com.ghostchu.quickshop.addon.reremakemigrator.shade.de.themoep.minedown.adventure.Util$TextControl is in module 'unnamed module' with loader 'Addon-Reremake-Migrator-6.3.0.0.jar' @4ebf592a, and sealed class net.kyori.adventure.text.format.TextFormat is in module 'unnamed module' with loader java.net.URLClassLoader @49c2faae
	at java.base/java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962) ~[?:?]
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:263) ~[leaf-api-26.2.build.37-alpha.jar:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:180) ~[leaf-api-26.2.build.37-alpha.jar:?]
	at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:175) ~[leaf-api-26.2.build.37-alpha.jar:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490) ~[?:?]
	at Addon-Reremake-Migrator-6.3.0.0.jar//com.ghostchu.quickshop.addon.reremakemigrator.shade.de.themoep.minedown.adventure.MineDownParser.parse(MineDownParser.java:215) ~[?:?]
	at Addon-Reremake-Migrator-6.3.0.0.jar//com.ghostchu.quickshop.addon.reremakemigrator.shade.de.themoep.minedown.adventure.MineDown.toComponent(MineDown.java:89) ~[?:?]
	at Addon-Reremake-Migrator-6.3.0.0.jar//com.ghostchu.quickshop.addon.reremakemigrator.shade.de.themoep.minedown.adventure.MineDown.parse(MineDown.java:67) ~[?:?]
	at Addon-Reremake-Migrator-6.3.0.0.jar//com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent.TranslationMigrateComponent.migrateFile(TranslationMigrateComponent.java:81) ~[?:?]
	at Addon-Reremake-Migrator-6.3.0.0.jar//com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent.TranslationMigrateComponent.migrate(TranslationMigrateComponent.java:46) ~[?:?]
	at Addon-Reremake-Migrator-6.3.0.0.jar//com.ghostchu.quickshop.addon.reremakemigrator.command.SubCommand_ReremakeMigrate.lambda$onCommand$1(SubCommand_ReremakeMigrate.java:65) ~[?:?]
	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[leaf-26.2.jar:26.2-37-3ead5ca]
	at org.bukkit.craftbukkit.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[leaf-26.2.jar:26.2-37-3ead5ca]
	at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[leaf-26.2.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```


---

## Type of Change

* [ ] Feature
* [X] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [X] I have tested these changes locally
* [X] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---