### PR TITLE
feat: added support for wildcard world blacklisting/whitelisting

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -491,12 +491,13 @@ public class Util {
 
   public static boolean isBlacklistWorld(@NotNull final World world) {
 
+    final String worldName = world.getName();
     final List<String> whitelist = plugin.getConfig().getStringList("shop.whitelist-world");
     if(!whitelist.isEmpty()) {
-      return !whitelist.contains(world.getName());
+      return whitelist.stream().noneMatch(entry->Pattern.matches(CommonUtil.createRegexFromGlob(entry), worldName));
     }
     // fall back to blacklist check
-    return plugin.getConfig().getStringList("shop.blacklist-world").contains(world.getName());
+    return plugin.getConfig().getStringList("shop.blacklist-world").stream().anyMatch(entry->Pattern.matches(CommonUtil.createRegexFromGlob(entry), worldName));
   }
 
   /**

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -676,10 +676,12 @@ shop:
   # Worlds where shop creation is allowed.
   # If not empty, only worlds in this list can create shops.
   # Takes priority over blacklist-world.
+  # Supports * and ? wildcards (e.g. spawn_*).
   whitelist-world: []
 
   # Worlds where shop creation is disallowed.
   # Only checked when whitelist-world is empty.
+  # Supports * and ? wildcards (e.g. speedrun_*).
   blacklist-world:
     - disabled_world_name
 


### PR DESCRIPTION
```markdown
<!--
Thanks for contributing to QuickShop-Hikari!
-->

This is a niche change, but it matters for servers that generate many similarly named worlds. Wildcard world lists cover that case without changing defaults or existing exact-name entries.

## Summary

Allow `*` and `?` wildcards in `shop.blacklist-world` and `shop.whitelist-world`, so entries like `speedrun_*` block shop creation in every matching world.

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Shop creation already refused worlds via exact `contains()` matches in `Util.isBlacklistWorld()`. That check now uses the existing `CommonUtil.createRegexFromGlob()` helper (same glob style as language filters).

* Exact names still match only that world (`disabled_world_name` → `^disabled_world_name$`)
* `speedrun_*` matches `speedrun_1`, `speedrun_nether`, etc.
* `?` matches a single character
* `whitelist-world` still takes priority when it is not empty, and uses the same matching
* Database loading lists (`database-loading-*-worlds`) are unchanged

---

## Config Changes (if applicable)

* Added/changed: comments on `shop.whitelist-world` and `shop.blacklist-world` documenting `*` / `?` support
* Default values: unchanged
* Any risks or notes: existing exact world names keep working; no migration needed
```