### PR TITLE
Fixed an issue where the call ConfigReloadevent was triggered

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -530,8 +530,10 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     } else {
       logWatcher = null;
     }
-    // Schedule this event can be run in next tick.
-    //Util.mainThreadRun(() -> new QSConfigurationReloadEvent(javaPlugin).callEvent());
+    // FoliaLib is initialized during onEnable, after the initial configuration load.
+    if(folia != null) {
+      Util.mainThreadRun(() -> new QSConfigurationReloadEvent(javaPlugin).callEvent());
+    }
   }
 
   public MainConfig mainConfig() {


### PR DESCRIPTION
…itialization was not fully successful

<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

FoliaLib that have not yet been created are no longer accessed during initial configuration loading; normal reloading after activation will still follow the original delayed event flow.


---

## Type of Change

* [ ] Feature
* [X] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [X] I have tested these changes locally
* [X] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---