### PR TITLE
Simplify price restrictions config

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
@@ -15,6 +15,7 @@ import com.ghostchu.quickshop.util.paste.item.SubPasteItem;
 import com.ghostchu.quickshop.util.paste.util.HTMLTable;
 import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.Reloadable;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -160,8 +161,15 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     final String bypassPermission = "quickshop.price.restriction.bypass." + ruleName;
     final ItemExpressionRegistry itemExpressionRegistry = (ItemExpressionRegistry)plugin.getRegistry().getRegistry(BuiltInRegistry.ITEM_EXPRESSION);
     final List<Function<ItemStack, Boolean>> items = new ArrayList<>();
-    for(final String item : section.getStringList("items")) {
+    final List<String> configuredItems = section.getStringList("items");
+    for(final String item : configuredItems) {
       items.add(itemStack->itemExpressionRegistry.match(itemStack, item));
+    }
+    if(configuredItems.isEmpty()) {
+      final Material material = Material.matchMaterial(ruleName);
+      if(material != null) {
+        items.add(itemStack->itemExpressionRegistry.match(itemStack, material.name()));
+      }
     }
     final List<Pattern> currency = new ArrayList<>();
     for(final String currencyStr1 : section.getStringList("currency")) {
@@ -503,15 +511,16 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     }
 
     /**
-     * Checks if the currency applies to this rule. Will return true if the currency is null
+     * Checks if the currency applies to this rule. A null currency or an empty configured
+     * currency list applies to every currency.
      *
      * @param currency the currency to check
      *
-     * @return true if the currency either applies, or is null. false otherwise.
+     * @return true if the currency applies or no currency filter is configured, false otherwise.
      */
     public boolean isApplicableCurrency(@Nullable final String currency) {
 
-      if(currency != null) {
+      if(currency != null && !this.currency.isEmpty()) {
         return this.currency.stream().anyMatch(pattern->pattern.matcher(currency).matches());
       }
       return true;

--- a/quickshop-bukkit/src/main/resources/price-restriction.yml
+++ b/quickshop-bukkit/src/main/resources/price-restriction.yml
@@ -15,6 +15,7 @@ rules: # Rules set
   example: # Rules name, used for identifier and permission node (quickshop.price.restriction.bypass.<name>)
     #items section SUPPORT Item Expression!
     #https://quickshop-community.github.io/QuickShop-Hikari-Documents/docs/modules/item-expression
+    # If omitted, the rule name (key) is used as the material name when it matches a Bukkit material.
     items: # Items in the rule (https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html), or the reference the item lookup table by adding @ before the name
       - STONE_SWORD
       - STONE_PICKAXE


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

This PR allows to simplify configuration of `price-restriction.yml` file.

Changes made:
- It is now optional to include currencies that the rule applies to. If `currencies` field is not present, the rule applies to all currencies. This greatly simplifies the config, especially if you have dozens or hundreds of rules - you don't have to repeat the redundant part over and over again
- For small rules covering only one item, it is now possible to omit `items` list field. If this field is not present, plugin tries to match the material basing on rule's name

### Before
```yml
netherite_ingot:
  items:
    - NETHERITE_INGOT
  currency:
    - '*'
  min: 600
  max: 1200
```
  
### After
```yml
netherite_ingot:
  min: 600
  max: 1200
 ```

The changes were tested and are fully compatible with the previous scheme and old config files.

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission