### PR TITLE
Fix parsing of default currency config in price restrictions

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
@@ -143,7 +143,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     final List<Pattern> currency = new ArrayList<>();
     for(final String currencyStr1 : section.getStringList("currency")) {
       try {
-        final Pattern pattern = Pattern.compile(currencyStr1);
+        final Pattern pattern = Pattern.compile(currencyStr1.equals("*")? ".*" : currencyStr1);
         currency.add(pattern);
       } catch(final PatternSyntaxException e) {
         plugin.logger().warn("Failed to read rule {}'s a Currency option, invalid pattern {}! Skipping...", ruleName, currencyStr1);


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
The default price restrictions config use '`*`' regex for economy filter, but '`*`' is an invalid regex, which causes an error:
`[QuickShop-Hikari] Failed to read rule netherite_ingot's a Currency option, invalid pattern *! Skipping...`

This PR just checks if an economy entry is '`*`' and if so, it uses '`.*`' regex instead for its parsing, which is a valid regex expression matching all string entries. I think this is a better option than switching to '`.*`' in the config itself, as it would be incompatible with previous configs, and also '`*`' is more intuitive for users.

The change was tested and is fully compatible with old configs.


*Example default configuration (for reference):*
```yml
rules:
  example1:
    items:
      - STONE_SWORD
    currency:
      - '*'
    min: 1.0
    max: 50.0
```
---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission