### PR TITLE
Separate price restrictions for selling and buying shops

### DIFF
--- a/crowdin/lang/en-US/messages.yml
+++ b/crowdin/lang/en-US/messages.yml
@@ -376,6 +376,7 @@ unknown-owner: Unknown
 restricted-prices: '<red>Restricted price for {0}: Min {1}, max {2}'
 restricted-price-max: '<red>Restricted price for {0}: Max {1}'
 restricted-price-min: '<red>Restricted price for {0}: Min {1}'
+shop-type-change-price-restricted: '<red>The current price is not valid for a {0} shop. The allowed range is {1} - {2}. Change the price before changing the shop type.'
 nearby-shop-this-way: <green>Shop is {0} block(s) away from you.
 owner-bypass-check: <yellow>Bypassed all checks. Trade successful! (You are now the shop owner!)
 april-rick-and-roll-easter-egg: "<hover:show_text:'Click to open in browser for time limited rewards!'><click:open_url:'https://www.youtube.com/watch?v=dQw4w9WgXcQ'><green>Click here to acquire your time limited rewards that provided by QuickShop-Hikari developer!</green></click></hover>"

--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/PriceLimiter.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/PriceLimiter.java
@@ -24,6 +24,12 @@ public interface PriceLimiter {
   @NotNull
   PriceLimiterCheckResult check(@NotNull CommandSender sender, @NotNull ItemStack stack, @Nullable String currency, double price);
 
+  @NotNull
+  default PriceLimiterCheckResult check(@NotNull CommandSender sender, @NotNull ItemStack stack, @Nullable String currency, double price,
+                                        @Nullable IShopType shopType) {
+    return check(sender, stack, currency, price);
+  }
+
   /**
    * Check the price restriction rules
    *
@@ -36,4 +42,10 @@ public interface PriceLimiter {
    */
   @NotNull
   PriceLimiterCheckResult check(@NotNull QUser user, @NotNull ItemStack stack, @Nullable String currency, double price);
+
+  @NotNull
+  default PriceLimiterCheckResult check(@NotNull QUser user, @NotNull ItemStack stack, @Nullable String currency, double price,
+                                        @Nullable IShopType shopType) {
+    return check(user, stack, currency, price);
+  }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Buy.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Buy.java
@@ -5,6 +5,7 @@ import com.ghostchu.quickshop.api.command.CommandHandler;
 import com.ghostchu.quickshop.api.command.CommandParser;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
+import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +28,9 @@ public class SubCommand_Buy implements CommandHandler<Player> {
     if(shop != null) {
       if(shop.playerAuthorize(sender.getUniqueId(), BuiltInShopPermission.SET_SHOPTYPE)
          || plugin.perm().hasPermission(sender, "quickshop.other.buy")) {
+        if(!ShopUtil.canChangeShopType(plugin, sender, shop, BUYING_TYPE)) {
+          return;
+        }
         shop.shopType(BUYING_TYPE);
         shop.setSignText(plugin.text().findRelativeLanguages(sender));
         plugin.text().of(sender, "command.now-buying", Util.getItemStackName(shop.getItem())).send();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Currency.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Currency.java
@@ -83,7 +83,7 @@ public class SubCommand_Currency implements CommandHandler<Player> {
           return;
         }
 
-        final PriceLimiterCheckResult checkResult = limiter.check(sender, shop.getItem(), event.updated(), shop.getPrice());
+        final PriceLimiterCheckResult checkResult = limiter.check(sender, shop.getItem(), event.updated(), shop.getPrice(), shop.shopType());
         if(checkResult.getStatus() != PriceLimiterStatus.PASS) {
           plugin.text().of(sender, "restricted-prices", Util.getItemStackName(shop.getItem()),
                            Component.text(checkResult.getMin()),

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Item.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Item.java
@@ -48,7 +48,7 @@ public class SubCommand_Item implements CommandHandler<Player> {
         itemStack.setAmount(1);
       }
       final PriceLimiter limiter = plugin.getShopManager().getPriceLimiter();
-      final PriceLimiterCheckResult checkResult = limiter.check(sender, itemStack, shop.getCurrency(), shop.getPrice());
+      final PriceLimiterCheckResult checkResult = limiter.check(sender, itemStack, shop.getCurrency(), shop.getPrice(), shop.shopType());
       if(checkResult.getStatus() != PriceLimiterStatus.PASS) {
         plugin.text().of(sender, "restricted-prices", Util.getItemStackName(shop.getItem()),
                          Component.text(checkResult.getMin()),

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Sell.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Sell.java
@@ -5,6 +5,7 @@ import com.ghostchu.quickshop.api.command.CommandHandler;
 import com.ghostchu.quickshop.api.command.CommandParser;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
+import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +28,9 @@ public class SubCommand_Sell implements CommandHandler<Player> {
     if(shop != null) {
       if(shop.playerAuthorize(sender.getUniqueId(), BuiltInShopPermission.SET_SHOPTYPE)
          || plugin.perm().hasPermission(sender, "quickshop.other.sell")) {
+        if(!ShopUtil.canChangeShopType(plugin, sender, shop, SELLING_TYPE)) {
+          return;
+        }
         shop.shopType(SELLING_TYPE);
         shop.setSignText(plugin.text().findRelativeLanguages(sender));
         plugin.text().of(sender, "command.now-selling", Util.getItemStackName(shop.getItem())).send();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Size.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Size.java
@@ -64,7 +64,7 @@ public class SubCommand_Size implements CommandHandler<Player> {
         final ItemStack pendingItemStack = shop.getItem().clone();
         pendingItemStack.setAmount(amount);
         final PriceLimiter limiter = plugin.getShopManager().getPriceLimiter();
-        final PriceLimiterCheckResult checkResult = limiter.check(sender, pendingItemStack, shop.getCurrency(), shop.getPrice());
+        final PriceLimiterCheckResult checkResult = limiter.check(sender, pendingItemStack, shop.getCurrency(), shop.getPrice(), shop.shopType());
         if(checkResult.getStatus() != PriceLimiterStatus.PASS) {
           plugin.text().of(sender, "restricted-prices", Util.getItemStackName(shop.getItem()),
                            Component.text(checkResult.getMin()),

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentBuy.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentBuy.java
@@ -5,6 +5,7 @@ import com.ghostchu.quickshop.api.command.CommandParser;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
 import com.ghostchu.quickshop.util.MsgUtil;
+import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +29,9 @@ public class SubCommand_SilentBuy extends SubCommand_SilentBase {
       return;
     }
 
+    if(!ShopUtil.canChangeShopType(plugin, sender, shop, BUYING_TYPE)) {
+      return;
+    }
     shop.shopType(BUYING_TYPE);
     shop.setSignText(plugin.text().findRelativeLanguages(sender));
     MsgUtil.sendControlPanelInfo(sender, shop);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentSell.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentSell.java
@@ -5,6 +5,7 @@ import com.ghostchu.quickshop.api.command.CommandParser;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
 import com.ghostchu.quickshop.util.MsgUtil;
+import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -31,6 +32,9 @@ public class SubCommand_SilentSell extends SubCommand_SilentBase {
       return;
     }
 
+    if(!ShopUtil.canChangeShopType(plugin, sender, shop, SELLING_TYPE)) {
+      return;
+    }
     shop.shopType(SELLING_TYPE);
     shop.setSignText(plugin.text().findRelativeLanguages(sender));
     MsgUtil.sendControlPanelInfo(sender, shop);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/keeper/MainPage.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/keeper/MainPage.java
@@ -266,11 +266,20 @@ public class MainPage extends QuickShopPage {
 
           final StateIcon changeIcon = new StateIcon(buyingStack, null, "SHOP_TYPE", modeState, (currentState)->{
             if(currentState.toUpperCase(Locale.ROOT).equals("SELLING")) {
+              if(!ShopUtil.canChangeShopType(QuickShop.getInstance(), player, shop.get(), BUYING_TYPE)) {
+                return currentState;
+              }
               Util.regionThread(shop.get().bukkitLocation(), ()->shop.get().shopType(BUYING_TYPE));
               return "BUYING";
             } else if(currentState.toUpperCase(Locale.ROOT).equals("BUYING")) {
+              if(!ShopUtil.canChangeShopType(QuickShop.getInstance(), player, shop.get(), SELLING_TYPE)) {
+                return currentState;
+              }
               Util.regionThread(shop.get().bukkitLocation(), ()->shop.get().shopType(SELLING_TYPE));
               return "SELLING";
+            }
+            if(!ShopUtil.canChangeShopType(QuickShop.getInstance(), player, shop.get(), SELLING_TYPE)) {
+              return currentState;
             }
             Util.regionThread(shop.get().bukkitLocation(), ()->shop.get().shopType(SELLING_TYPE));
             return "SELLING";

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
@@ -4,6 +4,7 @@ import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.obj.QUser;
 import com.ghostchu.quickshop.api.registry.BuiltInRegistry;
 import com.ghostchu.quickshop.api.registry.builtin.itemexpression.ItemExpressionRegistry;
+import com.ghostchu.quickshop.api.shop.IShopType;
 import com.ghostchu.quickshop.api.shop.PriceLimiter;
 import com.ghostchu.quickshop.api.shop.PriceLimiterCheckResult;
 import com.ghostchu.quickshop.api.shop.PriceLimiterStatus;
@@ -31,6 +32,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -43,8 +45,11 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
   private final QuickShop plugin;
   private final Map<String, RuleSet> rules = new LinkedHashMap<>();
   private boolean wholeNumberOnly = false;
-  private double undefinedMin = -1;
-  private double undefinedMax = -1;
+  private double globalSellingMin = -1;
+  private double globalSellingMax = -1;
+  private double globalBuyingMin = -1;
+  private double globalBuyingMax = -1;
+  private RuleScope defaultRuleScope = RuleScope.BUYING_AND_SELLING;
 
   public SimplePriceLimiter(@NotNull final QuickShop plugin) {
 
@@ -74,8 +79,12 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
         plugin.logger().warn("Failed to save migrated  price-restriction.yml.yml to plugin folder!", e);
       }
     }
-    this.undefinedMax = configuration.getDouble("undefined.max", -1);
-    this.undefinedMin = configuration.getDouble("undefined.min", -1);
+    this.globalSellingMax = configuration.getDouble("global.selling.max", -1);
+    this.globalSellingMin = configuration.getDouble("global.selling.min", -1);
+    this.globalBuyingMax = configuration.getDouble("global.buying.max", -1);
+    this.globalBuyingMin = configuration.getDouble("global.buying.min", -1);
+    this.defaultRuleScope = parseScope(configuration.getString("default-rule-scope"), RuleScope.BUYING_AND_SELLING,
+                                       "default-rule-scope");
     this.wholeNumberOnly = configuration.getBoolean("whole-number-only", false);
     if(!configuration.getBoolean("enable", false)) {
       return;
@@ -122,6 +131,19 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
       configuration.set("version", 3);
       anyChanges = true;
     }
+    if(configuration.getInt("version") == 3) {
+      Log.debug("Migrating price-restriction.yml from version 3 to version 4");
+      final double min = configuration.getDouble("undefined.min", 0.01);
+      final double max = configuration.getDouble("undefined.max", 1.0E29);
+      configuration.set("global.selling.min", min);
+      configuration.set("global.selling.max", max);
+      configuration.set("global.buying.min", min);
+      configuration.set("global.buying.max", max);
+      configuration.set("default-rule-scope", RuleScope.BUYING_AND_SELLING.name());
+      configuration.set("undefined", null);
+      configuration.set("version", 4);
+      anyChanges = true;
+    }
     return anyChanges;
   }
 
@@ -132,11 +154,12 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     if(section == null) {
       return null;
     }
-    final String bypassPermission = "quickshop.price.restriction.bypass." + ruleName;
-    final List<Function<ItemStack, Boolean>> items = new ArrayList<>();
     final double min = section.getDouble("min", 0.0);
     final double max = section.getDouble("max", Double.MAX_VALUE);
+    final RuleScope scope = parseScope(section.getString("scope"), defaultRuleScope, "rule " + ruleName);
+    final String bypassPermission = "quickshop.price.restriction.bypass." + ruleName;
     final ItemExpressionRegistry itemExpressionRegistry = (ItemExpressionRegistry)plugin.getRegistry().getRegistry(BuiltInRegistry.ITEM_EXPRESSION);
+    final List<Function<ItemStack, Boolean>> items = new ArrayList<>();
     for(final String item : section.getStringList("items")) {
       items.add(itemStack->itemExpressionRegistry.match(itemStack, item));
     }
@@ -149,7 +172,21 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
         plugin.logger().warn("Failed to read rule {}'s a Currency option, invalid pattern {}! Skipping...", ruleName, currencyStr1);
       }
     }
-    return new RuleSet(items, bypassPermission, currency, min, max);
+    return new RuleSet(items, bypassPermission, currency, scope, min, max);
+  }
+
+  private RuleScope parseScope(@Nullable final String configuredScope, @NotNull final RuleScope fallback,
+                               @NotNull final String settingName) {
+
+    if(configuredScope == null) {
+      return fallback;
+    }
+    try {
+      return RuleScope.valueOf(configuredScope.toUpperCase(Locale.ROOT));
+    } catch(final IllegalArgumentException exception) {
+      plugin.logger().warn("{} has an invalid scope. Using {}.", settingName, fallback);
+      return fallback;
+    }
   }
 
   /**
@@ -167,20 +204,32 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
      */
   @Override
   @NotNull
-  public PriceLimiterCheckResult check(@NotNull final CommandSender sender, @NotNull final ItemStack itemStack, @Nullable final String currency, final double price) {
+  public PriceLimiterCheckResult check(@NotNull final CommandSender sender, @NotNull final ItemStack itemStack,
+                                       @Nullable final String currency, final double price) {
+
+    return check(sender, itemStack, currency, price, null);
+  }
+
+  @Override
+  @NotNull
+  public PriceLimiterCheckResult check(@NotNull final CommandSender sender, @NotNull final ItemStack itemStack, @Nullable final String currency,
+                                       final double price, @Nullable final IShopType shopType) {
+
+    final double globalMin = globalMin(shopType);
+    final double globalMax = globalMax(shopType);
 
     if(Double.isInfinite(price) || Double.isNaN(price)) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_VALID, undefinedMin, undefinedMax);
+      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_VALID, globalMin, globalMax);
     }
     if(price < 0) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.REACHED_PRICE_MIN_LIMIT, 0.0d, undefinedMax);
+      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.REACHED_PRICE_MIN_LIMIT, 0.0d, globalMax);
     }
     if(wholeNumberOnly) {
       try {
         BigDecimal.valueOf(price).setScale(0, RoundingMode.UNNECESSARY);
       } catch(final ArithmeticException exception) {
         Log.debug(exception.getMessage());
-        return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_A_WHOLE_NUMBER, undefinedMin, undefinedMax);
+        return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_A_WHOLE_NUMBER, globalMin, globalMax);
       }
     }
 
@@ -191,7 +240,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     final List<ItemStack> flattenedItems = ItemContainerUtil.flattenContents(itemStack, true, false);
 
     for(final RuleSet rule : rules.values()) {
-      if(rule.canBypass(sender) || !rule.isApplicableCurrency(currency)) {
+      if(rule.canBypass(sender) || !rule.isApplicableCurrency(currency) || !rule.isApplicableShopType(shopType)) {
         continue;
       }
 
@@ -214,13 +263,13 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     }
 
     if ((hasMinPrice && price < minPrice) || (hasMaxPrice && price > maxPrice)
-        || (undefinedMin > 0 && price < undefinedMin) || (undefinedMax >= 0 && price > undefinedMax)) {
+        || (globalMin > 0 && price < globalMin) || (globalMax >= 0 && price > globalMax)) {
 
       return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED,
-                                               (hasMinPrice)? minPrice : undefinedMin,
-                                               (hasMaxPrice)? maxPrice : undefinedMax);
+                                               (hasMinPrice)? minPrice : globalMin,
+                                               (hasMaxPrice)? maxPrice : globalMax);
     }
-    return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, undefinedMin, undefinedMax);
+    return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, globalMin, globalMax);
   }
 
   /**
@@ -238,20 +287,32 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
      */
   @Override
   @NotNull
-  public PriceLimiterCheckResult check(@NotNull final QUser user, @NotNull final ItemStack itemStack, @Nullable final String currency, final double price) {
+  public PriceLimiterCheckResult check(@NotNull final QUser user, @NotNull final ItemStack itemStack,
+                                       @Nullable final String currency, final double price) {
+
+    return check(user, itemStack, currency, price, null);
+  }
+
+  @Override
+  @NotNull
+  public PriceLimiterCheckResult check(@NotNull final QUser user, @NotNull final ItemStack itemStack, @Nullable final String currency,
+                                       final double price, @Nullable final IShopType shopType) {
+
+    final double globalMin = globalMin(shopType);
+    final double globalMax = globalMax(shopType);
 
     if(Double.isInfinite(price) || Double.isNaN(price)) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_VALID, undefinedMin, undefinedMax);
+      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_VALID, globalMin, globalMax);
     }
     if(price < 0) {
-      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.REACHED_PRICE_MIN_LIMIT, 0.0d, undefinedMax);
+      return new SimplePriceLimiterCheckResult(PriceLimiterStatus.REACHED_PRICE_MIN_LIMIT, 0.0d, globalMax);
     }
     if(wholeNumberOnly) {
       try {
         BigDecimal.valueOf(price).setScale(0, RoundingMode.UNNECESSARY);
       } catch(final ArithmeticException exception) {
         Log.debug(exception.getMessage());
-        return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_A_WHOLE_NUMBER, undefinedMin, undefinedMax);
+        return new SimplePriceLimiterCheckResult(PriceLimiterStatus.NOT_A_WHOLE_NUMBER, globalMin, globalMax);
       }
     }
 
@@ -262,7 +323,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     final List<ItemStack> flattenedItems = ItemContainerUtil.flattenContents(itemStack, true, false);
 
     for(final RuleSet rule : rules.values()) {
-      if(rule.canBypass(user) || !rule.isApplicableCurrency(currency)) {
+      if(rule.canBypass(user) || !rule.isApplicableCurrency(currency) || !rule.isApplicableShopType(shopType)) {
         continue;
       }
 
@@ -285,13 +346,23 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     }
 
     if ((hasMinPrice && price < minPrice) || (hasMaxPrice && price > maxPrice)
-        || (undefinedMin > 0 && price < undefinedMin) || (undefinedMax >= 0 && price > undefinedMax)) {
+        || (globalMin > 0 && price < globalMin) || (globalMax >= 0 && price > globalMax)) {
 
       return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PRICE_RESTRICTED,
-                                               (hasMinPrice)? minPrice : undefinedMin,
-                                               (hasMaxPrice)? maxPrice : undefinedMax);
+                                               (hasMinPrice)? minPrice : globalMin,
+                                               (hasMaxPrice)? maxPrice : globalMax);
     }
-    return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, undefinedMin, undefinedMax);
+    return new SimplePriceLimiterCheckResult(PriceLimiterStatus.PASS, globalMin, globalMax);
+  }
+
+  private double globalMin(@Nullable final IShopType shopType) {
+
+    return shopType != null && shopType.isBuying()? globalBuyingMin : globalSellingMin;
+  }
+
+  private double globalMax(@Nullable final IShopType shopType) {
+
+    return shopType != null && shopType.isBuying()? globalBuyingMax : globalSellingMax;
   }
 
   @Override
@@ -308,8 +379,8 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     final StringJoiner joiner = new StringJoiner("<br/>");
     joiner.add("<h5>Metadata</h5>");
     final HTMLTable meta = new HTMLTable(2, true);
-    meta.insert("Undefined Minimum", undefinedMin);
-    meta.insert("Undefined Maximum", undefinedMax);
+    meta.insert("Buying Range", globalBuyingMin + " - " + globalBuyingMax);
+    meta.insert("Selling Range", globalSellingMin + " - " + globalSellingMax);
     meta.insert("Only WholeNumber", wholeNumberOnly);
     meta.insert("Rules", rules.size());
     joiner.add(meta.render());
@@ -340,14 +411,17 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
     private final List<Function<ItemStack, Boolean>> items;
     private final String bypassPermission;
     private final List<Pattern> currency;
+    private final RuleScope scope;
     private final double min;
     private final double max;
 
-    public RuleSet(final List<Function<ItemStack, Boolean>> items, final String bypassPermission, final List<Pattern> currency, final double min, final double max) {
+    public RuleSet(final List<Function<ItemStack, Boolean>> items, final String bypassPermission, final List<Pattern> currency,
+                   final RuleScope scope, final double min, final double max) {
 
       this.items = items;
       this.bypassPermission = bypassPermission;
       this.currency = currency;
+      this.scope = scope;
       this.min = min;
       this.max = max;
     }
@@ -443,6 +517,13 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
       return true;
     }
 
+    public boolean isApplicableShopType(@Nullable final IShopType shopType) {
+
+      return shopType == null || scope == RuleScope.BUYING_AND_SELLING
+             || scope == RuleScope.BUYING && shopType.isBuying()
+             || scope == RuleScope.SELLING && !shopType.isBuying();
+    }
+
     /**
      * Check if the rule is allowed to apply to the given price.
      *
@@ -529,19 +610,26 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
              && Double.compare(this.getMax(), other.getMax()) == 0
              && Objects.equals(this.getItems(), other.getItems())
              && Objects.equals(this.getBypassPermission(), other.getBypassPermission())
-             && Objects.equals(this.getCurrency(), other.getCurrency());
+             && Objects.equals(this.getCurrency(), other.getCurrency())
+             && this.scope == other.scope;
     }
 
     @Override
     public int hashCode() {
 
-      return Objects.hash(this.getMin(), this.getMax(), this.getItems(), this.getBypassPermission(), this.getCurrency());
+      return Objects.hash(this.getMin(), this.getMax(), this.getItems(), this.getBypassPermission(), this.getCurrency(), this.scope);
     }
 
     @Override
     public String toString() {
 
-      return "SimplePriceLimiter.RuleSet(items=" + this.getItems() + ", bypassPermission=" + this.getBypassPermission() + ", currency=" + this.getCurrency() + ", min=" + this.getMin() + ", max=" + this.getMax() + ")";
+      return "SimplePriceLimiter.RuleSet(items=" + this.getItems() + ", bypassPermission=" + this.getBypassPermission() + ", currency=" + this.getCurrency() + ", scope=" + this.scope + ", min=" + this.getMin() + ", max=" + this.getMax() + ")";
     }
+  }
+
+  private enum RuleScope {
+    BUYING,
+    SELLING,
+    BUYING_AND_SELLING
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -833,7 +833,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
     }
 
     // Price limit checking
-    final PriceLimiterCheckResult priceCheckResult = this.priceLimiter.check(p, shop.getItem(), plugin.getCurrency(), shop.getPrice());
+    final PriceLimiterCheckResult priceCheckResult = this.priceLimiter.check(p, shop.getItem(), plugin.getCurrency(), shop.getPrice(), shop.shopType());
     final String currency = (shop.getCurrency() == null)? ((plugin.getCurrency() == null)? "" : plugin.getCurrency()) : shop.getCurrency();
     final World world = shop.bukkitLocation().getWorld();
     final EconomyProvider econ = plugin.getEconomyManager().provider();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -26,8 +26,10 @@ import com.ghostchu.quickshop.api.event.settings.type.ShopPriceEvent;
 import com.ghostchu.quickshop.api.inventory.InventoryWrapper;
 import com.ghostchu.quickshop.api.obj.QUser;
 import com.ghostchu.quickshop.api.shop.Info;
+import com.ghostchu.quickshop.api.shop.IShopType;
 import com.ghostchu.quickshop.api.shop.PriceLimiter;
 import com.ghostchu.quickshop.api.shop.PriceLimiterCheckResult;
+import com.ghostchu.quickshop.api.shop.PriceLimiterStatus;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.ShopAction;
 import com.ghostchu.quickshop.api.shop.ShopManager;
@@ -64,6 +66,24 @@ import static com.ghostchu.quickshop.QuickShop.taskCache;
  * @since 6.2.0.8
  */
 public class ShopUtil {
+
+  public static boolean canChangeShopType(@NotNull final QuickShop plugin, @NotNull final Player player,
+                                          @NotNull final Shop shop, @NotNull final IShopType newType) {
+
+    if(shop.shopType().identifier().equalsIgnoreCase(newType.identifier())) {
+      return true;
+    }
+    final PriceLimiterCheckResult result = plugin.getShopManager().getPriceLimiter()
+            .check(player, shop.getItem(), shop.getCurrency(), shop.getPrice(), newType);
+    if(result.getStatus() == PriceLimiterStatus.PASS) {
+      return true;
+    }
+    plugin.text().of(player, "shop-type-change-price-restricted",
+                     plugin.text().of(player, newType.translationKey()).forLocale(),
+                     plugin.getShopManager().format(result.getMin(), shop),
+                     plugin.getShopManager().format(result.getMax(), shop)).send();
+    return false;
+  }
 
   public static boolean allowed(final Shop shop, final ItemStack itemStack) {
 
@@ -212,7 +232,7 @@ public class ShopUtil {
       }
     }
 
-    final PriceLimiterCheckResult checkResult = limiter.check(user, shop.getItem(), plugin.getCurrency(), price);
+    final PriceLimiterCheckResult checkResult = limiter.check(user, shop.getItem(), plugin.getCurrency(), price, shop.shopType());
     final String currency = (shop.getCurrency() == null)? ((plugin.getCurrency() == null)? "" : plugin.getCurrency()) : shop.getCurrency();
     final World world = shop.bukkitLocation().getWorld();
     final EconomyProvider econ = plugin.getEconomyManager().provider();

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -452,6 +452,7 @@ unknown-owner: Unknown
 restricted-prices: '<red>Restricted price for {0}: Min {1}, Max {2}'
 restricted-price-max: '<red>Restricted price for {0}: Max {1}'
 restricted-price-min: '<red>Restricted price for {0}: Min {1}'
+shop-type-change-price-restricted: '<red>The current price is not valid for a {0} shop. The allowed range is {1} - {2}. Change the price before changing the shop type.'
 nearby-shop-this-way: <green>Shop is {0} block(s) away from you.
 owner-bypass-check: <yellow>Bypassed all checks. Trade successful! (You are now the
   shop owner!)

--- a/quickshop-bukkit/src/main/resources/price-restriction.yml
+++ b/quickshop-bukkit/src/main/resources/price-restriction.yml
@@ -1,9 +1,16 @@
-version: 3
-whole-number-only: false  # This option not control by enable option, always enabled
-undefined: # This option not control by enable option, always enabled
-  min: 0.01 # Can be zero if you want player create a free shop
-  max: 999999999999999999999999999.99 # This can be up to 1.7976931348623157E308, or -1 to disable maximum price.
+version: 4
 enable: false
+whole-number-only: false  # This option not control by enable option, always enabled
+global: # These options are not controlled by enable; they are always enabled
+  selling:
+    min: 0.01 # Can be zero if you want players to create a free shop
+    max: 999999999999999999999999999.99 # Use -1 to disable the maximum price
+  buying:
+    min: 0.01
+    max: 999999999999999999999999999.99
+# Scope used when a rule does not define its own scope.
+# Allowed values: BUYING, SELLING, BUYING_AND_SELLING
+default-rule-scope: BUYING_AND_SELLING
 rules: # Rules set
   example: # Rules name, used for identifier and permission node (quickshop.price.restriction.bypass.<name>)
     #items section SUPPORT Item Expression!
@@ -16,5 +23,6 @@ rules: # Rules set
       - STONE_HOE
     currency: # Currency name, If your plugin doesn't support multi-currency (Vault API), this section won't be used
       - '*'
+    scope: BUYING_AND_SELLING # Optional: BUYING, SELLING, or BUYING_AND_SELLING (default)
     min: 1.0 # Min price (double)
     max: 50.0 # Max price (double)


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

This PR adds separate price restrictions for buying and selling shops.

Changes made:

- Global price restrictions are now configured separately under `global.selling` and `global.buying`
- Existing version 3 configurations are automatically migrated to version 4. Previous limits are copied to both shop types, preserving existing behavior
- Individual rules now support the optional scope field. Available options are `BUYING`, `SELLING`, and `BUYING_AND_SELLING`
- Added `default-rule-scope` config option, which determines the scope of rules that do not specify one. This helps to keep the config clean if e.g. most of rules are only for selling shops. It defaults to `BUYING_AND_SELLING`
- Price restrictions are now checked using the shop type when creating or modifying shops
- Changing the shop type between buying and selling is rejected if its current price is invalid for the target type
- The new shop-type-aware PriceLimiter overload is backward-compatible with existing implementations

I believe that `BUYING_AND_SELLING` is intuitive name for this option and is better than `ALL` or `BOTH`, because it clearly shows what does `scope` field mean.

### Before
```yml
version: 3

undefined:
  min: 0.01
  max: 25000

rules:
  netherite_ingot:
    min: 600
    max: 1200
```

### After
```yml
version: 4

global:
  selling:
    min: 0.01
    max: 25000
  buying:
    min: 0.01
    max: 25000

default-rule-scope: BUYING_AND_SELLING

rules:
  netherite_ingot:
    scope: SELLING
    min: 600
    max: 1200
```

*Note: above config examples of `netherite_ingot` rule use simplified scheme without `economy` and `items` fields proposed in PR #2505*

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Config Changes (if applicable)

Migrations are performed using an existing migration mechanism in `SimplePriceLimiter`