### PR TITLE
Fix translations being loaded twice at startup

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -472,12 +472,12 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     logger.info("Loading translations (This may take a while)...");
     try {
       this.textManager = new SimpleTextManager(this);
+      textManager.load();
     } catch(final NoSuchMethodError | NoClassDefFoundError e) {
       logger.error("Failed to initialize text manager, the QuickShop doesn't compatible with your Server version. Did you up-to-date?", e);
       Bukkit.getPluginManager().disablePlugin(javaPlugin);
       throw new IllegalStateException("Cannot initialize text manager");
     }
-    textManager.load();
   }
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/SimpleTextManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/SimpleTextManager.java
@@ -104,7 +104,6 @@ public class SimpleTextManager implements TextManager, Reloadable, SubPasteItem 
     } else {
       plugin.logger().info("[CrowdinOTA] Crowdin Over-The-Air distribution has been disabled.");
     }
-    load();
   }
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/SimpleTextManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/SimpleTextManager.java
@@ -111,7 +111,7 @@ public class SimpleTextManager implements TextManager, Reloadable, SubPasteItem 
    */
   public void load() {
 
-    plugin.logger().info("Loading up translations from Crowdin OTA, this may need a while...");
+    plugin.logger().info("Loading up translations from Crowdin OTA, this may take a while...");
     //TODO: This will break the message processing system in-game until loading finished, need to fix it.
     this.reset();
     initTagResolvers();


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

Fixes SimpleTextManager#load being called twice during startup

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---