### PR TITLE
Optimize/improve the shop manager

### DIFF
--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/ShopManager.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/ShopManager.java
@@ -17,6 +17,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Iterator;
 import java.util.List;
@@ -231,7 +232,8 @@ public interface ShopManager {
           @NotNull Shop shop,
           int amount);
 
-  void bakeShopRuntimeRandomUniqueIdCache(@NotNull Shop shop);
+  @Deprecated(since = "6.3.0.2")
+  default void bakeShopRuntimeRandomUniqueIdCache(@NotNull Shop shop) {}
 
   /**
    * Removes all shops from memory and the world. Does not delete them from the database. Call this
@@ -274,13 +276,12 @@ public interface ShopManager {
   String format(double d, @NotNull Shop shop);
 
   /**
-   * Returns all shops in the whole database, include unloaded.
-   *
-   * <p>Make sure you have caching this, because this need a while to get all shops
+   * Returns all shops in the whole database, including ones in unloaded chunks.
    *
    * @return All shop in the database
    */
   @NotNull
+  @Unmodifiable
   List<Shop> getAllShops();
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Browse.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Browse.java
@@ -54,14 +54,7 @@ public class SubCommand_Browse implements CommandHandler<Player> {
       final List<Shop> shops = new ArrayList<>();
 
       if(world) {
-        shops.addAll(plugin.getShopManager().getAllShops().stream().filter(shop->{
-          if(shop.bukkitLocation().getWorld() == null
-             || sender.getLocation().getWorld() == null) {
-            return false;
-          }
-
-          return shop.bukkitLocation().getWorld().getUID().equals(sender.getLocation().getWorld().getUID());
-        }).toList());
+        shops.addAll(plugin.getShopManager().getShopsInWorld(sender.getWorld()));
       } else {
         shops.addAll(plugin.getShopManager().getAllShops());
       }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_RemoveAll.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_RemoveAll.java
@@ -51,13 +51,7 @@ public class SubCommand_RemoveAll implements CommandHandler<CommandSender> {
                   return;
                 }
               }
-              final List<Shop> pendingRemoval = new ArrayList<>();
-              for(final Shop shop : plugin.getShopManager().getAllShops()) {
-                if(!shop.getOwner().equals(qUser)) {
-                  continue;
-                }
-                pendingRemoval.add(shop);
-              }
+              final List<Shop> pendingRemoval = plugin.getShopManager().getAllShops(qUser);
               pendingRemoval.forEach(shop->{
                 plugin.logEvent(new ShopRemoveLog(qUser, "Deleting shop " + shop + " as requested by the /quickshop removeall command.", shop.saveToInfoStorage()));
                 Util.regionThread(shop.bukkitLocation(), () -> plugin.getShopManager().deleteShop(shop));

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/papi/PAPICache.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/papi/PAPICache.java
@@ -59,9 +59,7 @@ public class PAPICache implements Reloadable {
 
   private long getShopsInWorld(@NotNull final String world, final boolean loadedOnly) {
 
-    return plugin.getShopManager().getAllShops().stream()
-            .filter(shop->shop.bukkitLocation().getWorld() != null)
-            .filter(shop->shop.bukkitLocation().getWorld().getName().equals(world))
+    return plugin.getShopManager().getShopsInWorld(world).stream()
             .filter(shop->!loadedOnly || shop.isLoaded())
             .count();
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
@@ -544,7 +544,7 @@ public abstract class AbstractShopManager implements ShopManager {
     final List<Shop> worldShops = new ArrayList<>();
 
     final Map<ShopChunk, Map<Location, Shop>> shopsInWorld = getShops(worldName);
-    for (final Map<Location, Shop> chunkEntry : shopsInWorld.values()) {
+    for(final Map<Location, Shop> chunkEntry : shopsInWorld.values()) {
 
         worldShops.addAll(chunkEntry.values());
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
@@ -17,9 +17,7 @@ import com.ghostchu.quickshop.shop.cache.SimpleShopCache;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.economyformatter.EconomyFormatter;
 import com.ghostchu.quickshop.util.logger.Log;
-import com.ghostchu.quickshop.util.performance.PerfMonitor;
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -46,7 +44,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 // This class is extract from SimpleShopManager because it is too big...
@@ -54,18 +51,11 @@ import java.util.function.Function;
 public abstract class AbstractShopManager implements ShopManager {
 
   protected static final DecimalFormat STANDARD_FORMATTER = new DecimalFormat("#.#########");
-  // the performance impact on busy server
-  protected final Cache<UUID, Shop> shopRuntimeUUIDCaching =
-          CacheBuilder.newBuilder()
-                  .expireAfterAccess(10, TimeUnit.MINUTES)
-                  .maximumSize(50)
-                  .weakValues()
-                  .initialCapacity(50)
-                  .build();
   protected final QuickShop plugin;
   protected final TradeService tradeService;
   protected final EconomyFormatter formatter;
   protected final Map<String, Map<ShopChunk, Map<Location, Shop>>> shops = Maps.newConcurrentMap();
+  protected final Map<UUID, Shop> allShops = Maps.newConcurrentMap();
   protected final Set<Shop> loadedShops = Sets.newConcurrentHashSet(); // Handle it by collection to reduce
   protected ShopCache shopCache;
 
@@ -101,8 +91,8 @@ public abstract class AbstractShopManager implements ShopManager {
     // Put it in the data universe
     // Calculate the chunks coordinates. These are 1,2,3 for each chunk, NOT
     // location rounded to the nearest 16.
-    final int x = (int)Math.floor((shop.bukkitLocation().getBlockX()) / 16.0);
-    final int z = (int)Math.floor((shop.bukkitLocation().getBlockZ()) / 16.0);
+    final int x = shop.bukkitLocation().getBlockX() >> 4;
+    final int z = shop.bukkitLocation().getBlockZ() >> 4;
     // Get the chunk set from the world info
     final ShopChunk shopChunk = new SimpleShopChunk(world, x, z);
     final Map<Location, Shop> inChunk =
@@ -112,12 +102,7 @@ public abstract class AbstractShopManager implements ShopManager {
     // Put the shop in its location in the chunk list.
     inChunk.put(shop.bukkitLocation(), shop);
     shopCache.invalidate(null, shop.bukkitLocation());
-  }
-
-  @Override
-  public void bakeShopRuntimeRandomUniqueIdCache(@NotNull final Shop shop) {
-
-    shopRuntimeUUIDCaching.put(shop.getRuntimeRandomUniqueId(), shop);
+    allShops.put(shop.getRuntimeRandomUniqueId(), shop);
   }
 
   /**
@@ -191,8 +176,8 @@ public abstract class AbstractShopManager implements ShopManager {
     if(inWorld == null) {
       return;
     }
-    final int x = (int)Math.floor((loc.getBlockX()) / 16.0);
-    final int z = (int)Math.floor((loc.getBlockZ()) / 16.0);
+    final int x = loc.getBlockX() >> 4;
+    final int z = loc.getBlockZ() >> 4;
     final ShopChunk shopChunk = new SimpleShopChunk(world, x, z);
     final Map<Location, Shop> inChunk = inWorld.get(shopChunk);
     if(inChunk == null) {
@@ -200,7 +185,7 @@ public abstract class AbstractShopManager implements ShopManager {
     }
     inChunk.remove(loc);
     shopCache.invalidate(null, shop.bukkitLocation());
-    shopRuntimeUUIDCaching.invalidate(shop.getRuntimeRandomUniqueId());
+    allShops.remove(shop.getRuntimeRandomUniqueId());
   }
 
 
@@ -269,27 +254,11 @@ public abstract class AbstractShopManager implements ShopManager {
             });
   }
 
-
-  /**
-   * Returns all shops in the memory, include unloaded.
-   *
-   * <p>Make sure you have caching this, because this need a while to get all shops
-   *
-   * @return All shop in the database
-   */
   @Override
   @NotNull
   public List<Shop> getAllShops() {
 
-    try(PerfMonitor ignored = new PerfMonitor("Getting all shops")) {
-      final List<Shop> shopsCollected = new ArrayList<>();
-      for(final Map<ShopChunk, Map<Location, Shop>> shopMapData : getShops().values()) {
-        for(final Map<Location, Shop> shopData : shopMapData.values()) {
-          shopsCollected.addAll(shopData.values());
-        }
-      }
-      return shopsCollected;
-    }
+    return List.copyOf(this.allShops.values());
   }
 
   /**
@@ -318,7 +287,7 @@ public abstract class AbstractShopManager implements ShopManager {
   public List<Shop> getAllShops(@NotNull final QUser playerUUID) {
 
     final List<Shop> playerShops = new ArrayList<>(10);
-    for(final Shop shop : getAllShops()) {
+    for(final Shop shop : this.allShops.values()) {
       if(shop.getOwner().equals(playerUUID)) {
         playerShops.add(shop);
       }
@@ -331,7 +300,7 @@ public abstract class AbstractShopManager implements ShopManager {
   public List<Shop> getAllShops(@NotNull final UUID playerUUID) {
 
     final List<Shop> playerShops = new ArrayList<>(10);
-    for(final Shop shop : getAllShops()) {
+    for(final Shop shop : this.allShops.values()) {
       final UUID shopUuid = shop.getOwner().getUniqueIdIfRealPlayer().orElse(null);
       if(playerUUID.equals(shopUuid)) {
         playerShops.add(shop);
@@ -352,7 +321,7 @@ public abstract class AbstractShopManager implements ShopManager {
   @Nullable
   public Shop getShop(final long shopId) {
 
-    for(final Shop shop : getAllShops()) {
+    for(final Shop shop : this.allShops.values()) {
       if(shop.getShopId() == shopId) {
         return shop;
       }
@@ -402,19 +371,8 @@ public abstract class AbstractShopManager implements ShopManager {
   public Shop getShopFromRuntimeRandomUniqueId(
           @NotNull final UUID runtimeRandomUniqueId, final boolean includeInvalid) {
 
-    final Shop shop = shopRuntimeUUIDCaching.getIfPresent(runtimeRandomUniqueId);
-    if(shop == null) {
-      for(final Shop shopWithoutCache : this.getLoadedShops()) {
-        if(shopWithoutCache.getRuntimeRandomUniqueId().equals(runtimeRandomUniqueId)) {
-          return shopWithoutCache;
-        }
-      }
-      return null;
-    }
-    if(includeInvalid) {
-      return shop;
-    }
-    if(shop.isValid()) {
+    final Shop shop = allShops.get(runtimeRandomUniqueId);
+    if(includeInvalid || shop.isValid()) {
       return shop;
     }
     return null;
@@ -576,14 +534,7 @@ public abstract class AbstractShopManager implements ShopManager {
   @NotNull
   public List<Shop> getShopsInWorld(@NotNull final World world) {
 
-    final List<Shop> worldShops = new ArrayList<>();
-    for(final Shop shop : getAllShops()) {
-      final Location location = shop.bukkitLocation();
-      if(location.isWorldLoaded() && Objects.equals(location.getWorld(), world)) {
-        worldShops.add(shop);
-      }
-    }
-    return worldShops;
+    return this.getShopsInWorld(world.getName());
   }
 
   @Override
@@ -591,12 +542,13 @@ public abstract class AbstractShopManager implements ShopManager {
   public List<Shop> getShopsInWorld(@NotNull final String worldName) {
 
     final List<Shop> worldShops = new ArrayList<>();
-    for(final Shop shop : getAllShops()) {
-      final Location location = shop.bukkitLocation();
-      if(location.isWorldLoaded() && com.ghostchu.quickshop.common.util.CommonUtil.strEquals(worldName, location.getWorld().getName())) {
-        worldShops.add(shop);
-      }
+
+    final Map<ShopChunk, Map<Location, Shop>> shopsInWorld = getShops(worldName);
+    for (final Map<Location, Shop> chunkEntry : shopsInWorld.values()) {
+
+        worldShops.addAll(chunkEntry.values());
     }
+
     return worldShops;
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -2250,38 +2250,4 @@ public class ContainerShop implements Shop<Double, Location>, Reloadable {
 
     return "ContainerShop{" + "location=" + location + ", plugin=" + plugin + ", runtimeRandomUniqueId=" + runtimeRandomUniqueId + ", playerGroup=" + playerGroup + ", isDeleted=" + isDeleted + ", extra=" + serializeExtra() + ", shopId=" + shopId + ", owner=" + owner + ", price=" + price + ", shopType=" + shopType + ", unlimited=" + unlimited + ", item=" + item + ", displayItem=" + displayItem + ", isLoaded=" + isLoaded + ", createBackup=" + createBackup + ", dirty=" + dirty + ", updating=" + updating + ", currency='" + currency + '\'' + ", disableDisplay=" + disableDisplay + ", taxAccount=" + taxAccount + ", inventoryWrapperProvider='" + inventoryWrapperProvider + '\'' + ", symbolLink='" + symbolLink + '\'' + ", shopName='" + shopName + '\'' + ", benefit=" + benefit + '}';
   }
-
-  @Override
-  public boolean equals(final Object o) {
-
-    if(o == this) return true;
-    if(!(o instanceof ContainerShop)) return false;
-    final ContainerShop other = (ContainerShop)o;
-    return this.getShopId() == other.getShopId()
-           && Double.compare(this.getPrice(), other.getPrice()) == 0
-           && this.isUnlimited() == other.isUnlimited()
-           && this.isDisableDisplay() == other.isDisableDisplay()
-           && Objects.equals(this.extraMap, other.extraMap)
-           && Objects.equals(this.getLocation(), other.getLocation())
-           && Objects.equals(this.playerGroup, other.playerGroup)
-           && Objects.equals(this.getOwner(), other.getOwner())
-           && Objects.equals(this.shopType, other.shopType)
-           && Objects.equals(this.shopState, other.shopState)
-           && Objects.equals(this.getItem(), other.getItem())
-           && Objects.equals(this.itemSerialize, other.itemSerialize)
-           && Objects.equals(this.getCurrency(), other.getCurrency())
-           && Objects.equals(this.getTaxAccount(), other.getTaxAccount())
-           && Objects.equals(this.getInventoryWrapperProvider(), other.getInventoryWrapperProvider())
-           && Objects.equals(this.symbolLink, other.symbolLink)
-           && Objects.equals(this.getShopName(), other.getShopName())
-           && Objects.equals(this.benefit, other.benefit)
-           && Objects.equals(this.updatingAtomic, other.updatingAtomic)
-           && Objects.equals(this.inFlightUpdate, other.inFlightUpdate);
-  }
-
-  @Override
-  public int hashCode() {
-
-    return Objects.hash(this.getShopId(), this.getPrice(), this.isUnlimited(), this.isDisableDisplay(), this.extraMap, this.getLocation(), this.playerGroup, this.getOwner(), this.shopType, this.shopState, this.getItem(), this.itemSerialize, this.getCurrency(), this.getTaxAccount(), this.getInventoryWrapperProvider(), this.symbolLink, this.getShopName(), this.benefit, this.updatingAtomic, this.inFlightUpdate);
-  }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopChunk.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopChunk.java
@@ -1,6 +1,7 @@
 package com.ghostchu.quickshop.shop;
 
 import com.ghostchu.quickshop.api.shop.ShopChunk;
+import it.unimi.dsi.fastutil.HashCommon;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
@@ -64,8 +65,7 @@ public class SimpleShopChunk implements ShopChunk {
   public boolean equals(final Object o) {
 
     if(o == this) return true;
-    if(!(o instanceof SimpleShopChunk)) return false;
-    final SimpleShopChunk other = (SimpleShopChunk)o;
+    if(!(o instanceof SimpleShopChunk other)) return false;
     return this.getX() == other.getX()
            && this.getZ() == other.getZ()
            && Objects.equals(this.getWorld(), other.getWorld());
@@ -74,7 +74,7 @@ public class SimpleShopChunk implements ShopChunk {
   @Override
   public int hashCode() {
 
-    return Objects.hash(this.getX(), this.getZ(), this.getWorld());
+    return Objects.hash(HashCommon.mix(this.getX()), this.getZ(), this.getWorld());
   }
 
   @Override

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -741,6 +741,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
     this.interactiveManager.reset();
     this.shops.clear();
     shopCache.invalidateAll(null);
+    this.allShops.clear();
   }
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -22,7 +22,6 @@ import com.ghostchu.quickshop.api.shop.Info;
 import com.ghostchu.quickshop.api.shop.PriceLimiter;
 import com.ghostchu.quickshop.api.shop.PriceLimiterCheckResult;
 import com.ghostchu.quickshop.api.shop.Shop;
-import com.ghostchu.quickshop.api.shop.ShopChunk;
 import com.ghostchu.quickshop.api.shop.ShopManager;
 import com.ghostchu.quickshop.api.shop.cache.ShopCacheNamespacedKey;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
@@ -95,7 +94,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1392,13 +1390,13 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
    * Returns a new shop iterator object, allowing iteration over shops easily, instead of sorting
    * through a 3D map.
    *
-   * @return a new shop iterator object.
+   * @return a new shop iterator object, removal is not supported.
    */
   @Override
   @NotNull
   public Iterator<Shop> getShopIterator() {
 
-    return new SimpleShopManager.ShopIterator();
+    return getAllShops().iterator();
   }
 
   @Override
@@ -1669,64 +1667,6 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
           plugin.getBungeeListener().notifyForForward(p);
         }
       }
-    }
-  }
-
-  public class ShopIterator implements Iterator<Shop> {
-
-    protected final Iterator<Map<ShopChunk, Map<Location, Shop>>> worlds;
-
-    protected Iterator<Map<Location, Shop>> chunks;
-
-    protected Iterator<Shop> shops;
-
-    public ShopIterator() {
-
-      worlds = getShops().values().iterator();
-    }
-
-    /**
-     * Returns true if there is still more shops to iterate over.
-     */
-    @Override
-    public boolean hasNext() {
-
-      if(shops == null || !shops.hasNext()) {
-        if(chunks == null || !chunks.hasNext()) {
-          if(!worlds.hasNext()) {
-            return false;
-          } else {
-            chunks = worlds.next().values().iterator();
-            return hasNext();
-          }
-        } else {
-          shops = chunks.next().values().iterator();
-          return hasNext();
-        }
-      }
-      return true;
-    }
-
-    /**
-     * Fetches the next shop. Throws NoSuchElementException if there are no more shops.
-     */
-    @Override
-    @NotNull
-    public Shop next() {
-
-      if(shops == null || !shops.hasNext()) {
-        if(chunks == null || !chunks.hasNext()) {
-          if(!worlds.hasNext()) {
-            throw new NoSuchElementException("No more shops to iterate over!");
-          }
-          chunks = worlds.next().values().iterator();
-        }
-        shops = chunks.next().values().iterator();
-      }
-      if(!shops.hasNext()) {
-        return this.next(); // Skip to the next one (Empty iterator?)
-      }
-      return shops.next();
     }
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/MsgUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/MsgUtil.java
@@ -494,7 +494,6 @@ public class MsgUtil {
       Log.debug("ControlPanel blocked by 3rd-party");
       return;
     }
-    PLUGIN.getShopManager().bakeShopRuntimeRandomUniqueIdCache(shop);
     PLUGIN.getShopControlPanelManager().openControlPanel((Player)sender, shop);
 
   }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

This main improvement in this PR is adding a new map to the shop manager of runtime uuid -> shop instance, which serves 2 purposes:
- Replacing the existing short lived cache of uuid -> shop instance
- Having a flat set of all loaded shops, to improve the efficiency of getAllShops and anything else that relies on that method

Other improvements & their motivations:
- ContainerShop#equals/hashCode: assuming the invariant holds that no more than one ContainerShop instance may exist at a time for any given physical shop, it's safe to rely on the identity equals/hashCode. The current impl isn't ideal since it can fire 4-8 events to retrieve something, and the hashCode may change when modifying the shop.
- SimpleShopChunk hashCode: by mixing the bits around of one of the components you can get much better average hashcode uniqueness
---

## Type of Change

* [ ] Feature
* [ ] Bug fix
* [x] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---