### PR TITLE
[Feature] Move set type and state to administrators

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,10 @@ tasks.register<Copy>("collectReleaseArtifacts") {
 
     subprojects.forEach { subproject ->
         from(subproject.layout.buildDirectory.dir("libs")) {
-            include("*.jar")
+            include("QuickShop-Hikari-*.jar")
+            include("Addon-*.jar")
+            include("Compat-*.jar")
+
             exclude("*-sources.jar")
             exclude("*-javadoc.jar")
         }

--- a/compatibility/matcherplus/src/main/java/com/ghostchu/quickshop/compatibility/matcherplus/matchers/impl/PyroFishingCheck.java
+++ b/compatibility/matcherplus/src/main/java/com/ghostchu/quickshop/compatibility/matcherplus/matchers/impl/PyroFishingCheck.java
@@ -31,6 +31,9 @@ import org.jetbrains.annotations.Nullable;
  */
 public class PyroFishingCheck implements ItemCheck {
 
+  final NamespacedKey fishNumberKey = new NamespacedKey("pyrofishingpro", "fishnumber");
+  final NamespacedKey tierKey = new NamespacedKey("pyrofishingpro", "tier");
+
   /**
    * Check if this check applies to the specified ItemStack
    *
@@ -45,7 +48,8 @@ public class PyroFishingCheck implements ItemCheck {
 
       return false;
     }
-    return stack.getItemMeta().getPersistentDataContainer().has(new NamespacedKey("pyrofishingpro", "fishnumber"), PersistentDataType.INTEGER);
+    return stack.getItemMeta().getPersistentDataContainer().has(fishNumberKey, PersistentDataType.INTEGER)
+           && stack.getItemMeta().getPersistentDataContainer().has(tierKey, PersistentDataType.STRING);
   }
 
   /**
@@ -59,17 +63,28 @@ public class PyroFishingCheck implements ItemCheck {
   @Override
   public boolean matches(final @Nullable ItemStack stack, final @Nullable ItemStack compare) {
 
-    final int originalFish = fishData(stack);
-    final int testerFish = fishData(compare);
+    final int originalFishNumber = fishNumber(stack);
+    final int testerFishNumber = fishNumber(compare);
 
-    return originalFish == testerFish;
+    final String originalFishTier = fishTier(stack);
+    final String testerFishTier = fishTier(compare);
+
+    return originalFishNumber == testerFishNumber && originalFishTier.equalsIgnoreCase(testerFishTier);
   }
 
-  public Integer fishData(final ItemStack stack) {
+  public Integer fishNumber(final ItemStack stack) {
 
     if(stack.getItemMeta() != null) {
-      return stack.getItemMeta().getPersistentDataContainer().getOrDefault(new NamespacedKey("pyrofishingpro", "fishnumber"), PersistentDataType.INTEGER, -1);
+      return stack.getItemMeta().getPersistentDataContainer().getOrDefault(fishNumberKey, PersistentDataType.INTEGER, -1);
     }
     return -1;
+  }
+
+  public String fishTier(final ItemStack stack) {
+
+    if(stack.getItemMeta() != null) {
+      return stack.getItemMeta().getPersistentDataContainer().getOrDefault(tierKey, PersistentDataType.STRING, "NO_TIER");
+    }
+    return "NO_TIER";
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

What does this PR do?

This is a feature to move the set type and state to the administrator group, which addresses #2539 . Not really a required feature, isn't really an exploit either as staff should be trustworthy players, but potentially helps idiot proof server setups for players.

---

## Type of Change

* [X] Feature
* [ ] Bug fix
* [ ] Refactor / Cleanup
* [ ] Documentation
* [ ] Breaking change

---

## Basic Checks

* [X] I have tested these changes locally
* [X] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---